### PR TITLE
Fix the C0 errs value in mbe 2450/4400Dataf()

### DIFF
--- a/src/ambe/ambe3600x2450.c
+++ b/src/ambe/ambe3600x2450.c
@@ -742,9 +742,8 @@ mbe_processAmbe2450Dataf_internal(float* aout_buf, const int* errs2, char* err_s
 void
 mbe_processAmbe2450Dataf(float* aout_buf, const int* errs, const int* errs2, char* err_str, const char ambe_d[49],
                          mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
-    (void)errs;
-    mbe_processAmbe2450Dataf_internal(aout_buf, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality, 0,
-                                      0);
+    mbe_processAmbe2450Dataf_internal(aout_buf, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality, *errs,
+                                      1);
 }
 
 /**

--- a/src/imbe/imbe7200x4400.c
+++ b/src/imbe/imbe7200x4400.c
@@ -663,9 +663,8 @@ mbe_processImbe4400Dataf_withC0(float* aout_buf, const int* errs2, char* err_str
 void
 mbe_processImbe4400Dataf(float* aout_buf, const int* errs, const int* errs2, char* err_str, const char imbe_d[88],
                          mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
-    (void)errs;
-    mbe_processImbe4400Dataf_withC0(aout_buf, errs2, err_str, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality, 0,
-                                    0);
+    mbe_processImbe4400Dataf_withC0(aout_buf, errs2, err_str, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality, *errs,
+                                    1);
 }
 
 /**


### PR DESCRIPTION
Hi,
I think the 'errs' parameter contains the c0 errors, and it could be used by the *internal functions.

Cheers,

Shawn