### PR TITLE
Run required CI for all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,8 @@ on:
     branches: [main, master]
     tags:
       - "v*.*.*"
-    paths-ignore:
-      - ".*"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - ".github/**/*.yml"
-      - ".github/**/*.yaml"
-      - "**/*.md"
   pull_request:
     branches: [main, master]
-    paths-ignore:
-      - ".*"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - ".github/**/*.yml"
-      - ".github/**/*.yaml"
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Remove path filters from the required `CI` workflow so required check contexts are created for every pull request, including documentation-only and workflow-only changes.

## Goal

Branch protection now requires checks from this workflow. If the workflow is skipped by `paths-ignore`, those required contexts never appear and otherwise valid pull requests can be blocked indefinitely.

## Validation

- Commit is GPG-signed locally.
- Scope is limited to `.github/workflows/ci.yml`.
