### PR TITLE
Fix AUR SSH host key verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,15 +336,16 @@ jobs:
       - name: Setup SSH for AUR
         if: steps.aur_key.outputs.has_key == 'true'
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/aur
-          chmod 600 ~/.ssh/aur
-          ssh-keyscan -t ed25519 aur.archlinux.org >> ~/.ssh/known_hosts
+          mkdir -p "$HOME/.ssh"
+          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > "$HOME/.ssh/aur"
+          chmod 600 "$HOME/.ssh/aur"
+          ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
       - name: Clone AUR package
         if: steps.aur_key.outputs.has_key == 'true'
         run: |
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/aur" git clone ssh://aur@aur.archlinux.org/mbelib-neo-git.git aur-package
+          aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
+          GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/mbelib-neo-git.git aur-package
           git config --global --add safe.directory "$GITHUB_WORKSPACE/aur-package"
 
       - name: Compute new pkgver
@@ -397,7 +398,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add PKGBUILD .SRCINFO
           git commit -m "Update to ${{ steps.pkgver.outputs.pkgver }}"
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/aur" git push origin master
+          aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
+          GIT_SSH_COMMAND="$aur_ssh_command" git push origin master
 
   update-aur-release:
     name: Update AUR package (release)
@@ -448,15 +450,16 @@ jobs:
       - name: Setup SSH for AUR
         if: steps.aur_key.outputs.has_key == 'true'
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/aur
-          chmod 600 ~/.ssh/aur
-          ssh-keyscan -t ed25519 aur.archlinux.org >> ~/.ssh/known_hosts
+          mkdir -p "$HOME/.ssh"
+          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > "$HOME/.ssh/aur"
+          chmod 600 "$HOME/.ssh/aur"
+          ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
       - name: Clone AUR package
         if: steps.aur_key.outputs.has_key == 'true'
         run: |
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/aur" git clone ssh://aur@aur.archlinux.org/mbelib-neo.git aur-package
+          aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
+          GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/mbelib-neo.git aur-package
           git config --global --add safe.directory "$GITHUB_WORKSPACE/aur-package"
 
       - name: Compute release metadata
@@ -512,7 +515,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add PKGBUILD .SRCINFO
           git commit -m "Update to ${{ steps.release_meta.outputs.pkgver }}"
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/aur" git push origin master
+          aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
+          GIT_SSH_COMMAND="$aur_ssh_command" git push origin master
 
   install-and-consume:
     needs: [format-check, clang-tidy, cppcheck, scan-build, semgrep]


### PR DESCRIPTION
## Summary
- Use explicit `$HOME/.ssh` paths when preparing the AUR SSH key and known-hosts file.
- Pass `IdentitiesOnly`, `UserKnownHostsFile`, and strict host checking through `GIT_SSH_COMMAND` for AUR clone and push steps.
- Apply the same SSH handling to both git and release AUR update jobs.

## Root Cause
The Arch container job writes SSH files under `$HOME`, but OpenSSH resolves its default `~/.ssh/known_hosts` path from root's passwd home. That makes host key verification look in `/root/.ssh/known_hosts` instead of the populated `$HOME/.ssh/known_hosts` file.

## Validation
- `actionlint .github/workflows/ci.yml`
- `tools/preflight_ci.sh --base origin/main`
- `git push -u origin fix/aur-ssh-known-hosts`