### PR TITLE
align quality and security guardrails

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ mapfile -t staged_paths < <(git diff --cached --name-only --diff-filter=ACMR | g
 files=()
 for p in "${staged_paths[@]}"; do
   case "$p" in
-    build/*|src/external/*) continue ;;
+    build/* | src/external/*) continue ;;
   esac
   files+=("$p")
 done
@@ -18,7 +18,7 @@ if [[ ${#files[@]} -eq 0 ]]; then
   exit 0
 fi
 
-if ! command -v clang-format >/dev/null 2>&1; then
+if ! command -v clang-format > /dev/null 2>&1; then
   echo "clang-format not found in PATH. Install it to proceed." >&2
   exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Pre-push hook: run local CI-style analysis on files changed in the push.
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+repo_root=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$repo_root"
 
 remote_name="${1:-origin}"
@@ -12,7 +12,10 @@ remote_url="${2:-}"
 # Controls:
 # - MBE_HOOK_FAIL_ON_MISSING_TOOLS: 1|0 (default: 0)
 #   when 1, missing analyzers make the hook fail.
+# - MBE_HOOK_RUN_SCAN_BUILD: 1|0 (default: 0)
+#   when 1, also runs the heavier full scan-build pass.
 FAIL_ON_MISSING_TOOLS="${MBE_HOOK_FAIL_ON_MISSING_TOOLS:-0}"
+RUN_SCAN_BUILD="${MBE_HOOK_RUN_SCAN_BUILD:-0}"
 
 if [[ -n "$remote_url" ]]; then
   echo "pre-push: remote=${remote_name} url=<provided>"
@@ -22,7 +25,7 @@ fi
 
 zeros="0000000000000000000000000000000000000000"
 
-remote_head_ref=$(git symbolic-ref -q "refs/remotes/${remote_name}/HEAD" 2>/dev/null || true)
+remote_head_ref=$(git symbolic-ref -q "refs/remotes/${remote_name}/HEAD" 2> /dev/null || true)
 if [[ -z "$remote_head_ref" ]]; then
   if git show-ref --verify --quiet "refs/remotes/${remote_name}/main"; then
     remote_head_ref="refs/remotes/${remote_name}/main"
@@ -47,7 +50,7 @@ resolve_new_ref_base() {
 
 remote_tracking_refs=()
 mapfile -t remote_tracking_refs < <(
-  git for-each-ref --format='%(refname)' "refs/remotes/${remote_name}" 2>/dev/null || true
+  git for-each-ref --format='%(refname)' "refs/remotes/${remote_name}" 2> /dev/null || true
 )
 
 select_best_remote_merge_base() {
@@ -59,11 +62,11 @@ select_best_remote_merge_base() {
   local best_distance=""
 
   for ref in "${remote_tracking_refs[@]}"; do
-    merge_base=$(git merge-base "$local_sha" "$ref" 2>/dev/null || true)
+    merge_base=$(git merge-base "$local_sha" "$ref" 2> /dev/null || true)
     if [[ -z "$merge_base" ]]; then
       continue
     fi
-    distance=$(git rev-list --count "${merge_base}..${local_sha}" 2>/dev/null || true)
+    distance=$(git rev-list --count "${merge_base}..${local_sha}" 2> /dev/null || true)
     if [[ -z "$distance" ]]; then
       continue
     fi
@@ -98,7 +101,7 @@ new_ref_diff_files_fallback() {
   git diff --name-only --diff-filter=ACMR "${empty_tree}" "${local_sha}^{tree}" || true
 }
 
-head_sha=$(git rev-parse -q --verify HEAD 2>/dev/null || true)
+head_sha=$(git rev-parse -q --verify HEAD 2> /dev/null || true)
 
 changed_paths=()
 head_changed_paths=()
@@ -147,22 +150,52 @@ done
 changed_sources=()
 changed_headers=()
 format_files=()
+cmake_format_files=()
 semgrep_targets=()
+shell_lint_targets=()
+workflow_lint_targets=()
+workflow_security_targets=()
+dependency_scan_targets=()
 missing_worktree_paths=()
 skipped_missing_paths=()
 for p in "${changed_paths[@]}"; do
   case "$p" in
-    build/*|src/external/*) continue ;;
+    build/* | src/external/*) continue ;;
   esac
 
   track_semgrep=0
   case "$p" in
-    src/*|include/*|examples/*|bench/*|tests/*|tools/*) track_semgrep=1 ;;
+    src/* | include/* | examples/* | bench/* | tests/* | tools/* | .github/workflows/*.yml | .github/workflows/*.yaml)
+      track_semgrep=1
+      ;;
+  esac
+
+  case "$p" in
+    *.sh | .githooks/*) shell_lint_targets+=("$p") ;;
+    .github/workflows/*.yml | .github/workflows/*.yaml) workflow_lint_targets+=("$p") ;;
+  esac
+
+  case "$p" in
+    CMakeLists.txt | */CMakeLists.txt | CMakeLists.txt.in | */CMakeLists.txt.in | *.cmake | *.cmake.in)
+      cmake_format_files+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    .github/workflows/*.yml | .github/workflows/*.yaml | .github/dependabot.yml | .github/zizmor.yml)
+      workflow_security_targets+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    .github/dependabot.yml | tools/osv_scan.sh | src/external/*)
+      dependency_scan_targets+=("$p")
+      ;;
   esac
 
   track_c_family=0
   case "$p" in
-    *.c|*.cc|*.cpp|*.cxx|*.h|*.hh|*.hpp|*.hxx) track_c_family=1 ;;
+    *.c | *.cc | *.cpp | *.cxx | *.h | *.hh | *.hpp | *.hxx) track_c_family=1 ;;
   esac
 
   if [[ ! -e "$p" && ! -L "$p" ]]; then
@@ -181,11 +214,11 @@ for p in "${changed_paths[@]}"; do
   fi
 
   case "$p" in
-    *.c|*.cc|*.cpp|*.cxx)
+    *.c | *.cc | *.cpp | *.cxx)
       changed_sources+=("$p")
       format_files+=("$p")
       ;;
-    *.h|*.hh|*.hpp|*.hxx)
+    *.h | *.hh | *.hpp | *.hxx)
       changed_headers+=("$p")
       format_files+=("$p")
       ;;
@@ -197,6 +230,21 @@ if [[ ${#format_files[@]} -gt 0 ]]; then
 fi
 if [[ ${#semgrep_targets[@]} -gt 0 ]]; then
   mapfile -t semgrep_targets < <(printf '%s\n' "${semgrep_targets[@]}" | sort -u)
+fi
+if [[ ${#cmake_format_files[@]} -gt 0 ]]; then
+  mapfile -t cmake_format_files < <(printf '%s\n' "${cmake_format_files[@]}" | sort -u)
+fi
+if [[ ${#shell_lint_targets[@]} -gt 0 ]]; then
+  mapfile -t shell_lint_targets < <(printf '%s\n' "${shell_lint_targets[@]}" | sort -u)
+fi
+if [[ ${#workflow_lint_targets[@]} -gt 0 ]]; then
+  mapfile -t workflow_lint_targets < <(printf '%s\n' "${workflow_lint_targets[@]}" | sort -u)
+fi
+if [[ ${#workflow_security_targets[@]} -gt 0 ]]; then
+  mapfile -t workflow_security_targets < <(printf '%s\n' "${workflow_security_targets[@]}" | sort -u)
+fi
+if [[ ${#dependency_scan_targets[@]} -gt 0 ]]; then
+  mapfile -t dependency_scan_targets < <(printf '%s\n' "${dependency_scan_targets[@]}" | sort -u)
 fi
 if [[ ${#skipped_missing_paths[@]} -gt 0 ]]; then
   mapfile -t skipped_missing_paths < <(printf '%s\n' "${skipped_missing_paths[@]}" | sort -u)
@@ -228,16 +276,16 @@ collect_header_includers() {
   mapfile -t c_matches < <(
     rg -l --glob '!src/external/**' \
       -g'*.c' \
-      "$pattern" src tests examples bench 2>/dev/null \
-      | sort \
-      | head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+      "$pattern" src tests examples bench 2> /dev/null |
+      sort |
+      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
   )
   mapfile -t cxx_matches < <(
     rg -l --glob '!src/external/**' \
       -g'*.cc' -g'*.cpp' -g'*.cxx' \
-      "$pattern" src tests examples bench 2>/dev/null \
-      | sort \
-      | head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+      "$pattern" src tests examples bench 2> /dev/null |
+      sort |
+      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
   )
 
   for c_file in "${c_matches[@]}"; do
@@ -249,7 +297,7 @@ collect_header_includers() {
 }
 
 if [[ ${#changed_headers[@]} -gt 0 ]]; then
-  if command -v rg >/dev/null 2>&1; then
+  if command -v rg > /dev/null 2>&1; then
     for hdr in "${changed_headers[@]}"; do
       include_key=""
       if [[ "$hdr" == include/* ]]; then
@@ -319,10 +367,10 @@ run_clang_format_check() {
   local rc=0
   local f=""
   for f in "$@"; do
-    if clang-format -n --Werror "$f" >/dev/null 2>&1; then
+    if clang-format -n --Werror "$f" > /dev/null 2>&1; then
       continue
     fi
-    if ! diff -u "$f" <(clang-format "$f") >/dev/null; then
+    if ! diff -u "$f" <(clang-format "$f") > /dev/null; then
       echo "pre-push: formatting issues found in ${f}" >&2
       rc=1
     fi
@@ -331,15 +379,23 @@ run_clang_format_check() {
 }
 
 if [[ ${#format_files[@]} -gt 0 ]]; then
-  if command -v clang-format >/dev/null 2>&1; then
+  if command -v clang-format > /dev/null 2>&1; then
     run_check "clang-format check (${#format_files[@]} file(s))" run_clang_format_check "${format_files[@]}"
   else
     mark_missing_tool "clang-format" "format check"
   fi
 fi
 
+if [[ ${#cmake_format_files[@]} -gt 0 ]]; then
+  if command -v gersemi > /dev/null 2>&1; then
+    run_check "gersemi check (${#cmake_format_files[@]} file(s))" tools/cmake_format_check.sh -- "${cmake_format_files[@]}"
+  else
+    mark_missing_tool "gersemi" "CMake format check"
+  fi
+fi
+
 if [[ ${#analysis_tus[@]} -gt 0 ]]; then
-  if command -v clang-tidy >/dev/null 2>&1; then
+  if command -v clang-tidy > /dev/null 2>&1; then
     run_check "clang-tidy strict (${#analysis_tus[@]} TU(s))" tools/clang_tidy.sh --strict -- "${analysis_tus[@]}"
   else
     mark_missing_tool "clang-tidy" "clang-tidy analysis"
@@ -347,7 +403,7 @@ if [[ ${#analysis_tus[@]} -gt 0 ]]; then
 fi
 
 if [[ ${#cppcheck_sources[@]} -gt 0 ]]; then
-  if command -v cppcheck >/dev/null 2>&1; then
+  if command -v cppcheck > /dev/null 2>&1; then
     run_check "cppcheck strict (${#cppcheck_sources[@]} TU(s))" tools/cppcheck.sh --strict -- "${cppcheck_sources[@]}"
   else
     mark_missing_tool "cppcheck" "cppcheck analysis"
@@ -355,7 +411,7 @@ if [[ ${#cppcheck_sources[@]} -gt 0 ]]; then
 fi
 
 if [[ ${#analysis_tus[@]} -gt 0 ]]; then
-  if command -v include-what-you-use >/dev/null 2>&1; then
+  if command -v include-what-you-use > /dev/null 2>&1; then
     run_check "IWYU strict (${#analysis_tus[@]} TU(s))" tools/iwyu.sh --strict -- "${analysis_tus[@]}"
   else
     mark_missing_tool "include-what-you-use" "IWYU analysis"
@@ -363,7 +419,7 @@ if [[ ${#analysis_tus[@]} -gt 0 ]]; then
 fi
 
 if [[ ${#analysis_tus[@]} -gt 0 ]]; then
-  if command -v gcc >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1; then
+  if command -v gcc > /dev/null 2>&1 && command -v g++ > /dev/null 2>&1; then
     run_check "GCC fanalyzer strict (${#analysis_tus[@]} TU(s))" tools/gcc_fanalyzer.sh --strict -- "${analysis_tus[@]}"
   else
     mark_missing_tool "gcc/g++" "GCC fanalyzer analysis"
@@ -371,23 +427,59 @@ if [[ ${#analysis_tus[@]} -gt 0 ]]; then
 fi
 
 if [[ ${#semgrep_targets[@]} -gt 0 ]]; then
-  if command -v semgrep >/dev/null 2>&1; then
+  if command -v semgrep > /dev/null 2>&1; then
     run_check "Semgrep strict (${#semgrep_targets[@]} path(s))" tools/semgrep.sh --strict -- "${semgrep_targets[@]}"
   else
     mark_missing_tool "semgrep" "Semgrep analysis"
   fi
 fi
 
-if command -v lizard >/dev/null 2>&1; then
+if [[ ${#shell_lint_targets[@]} -gt 0 ]]; then
+  if command -v shellcheck > /dev/null 2>&1 && command -v shfmt > /dev/null 2>&1; then
+    run_check "shell lint (${#shell_lint_targets[@]} file(s))" tools/shell_lint.sh -- "${shell_lint_targets[@]}"
+  else
+    mark_missing_tool "shellcheck/shfmt" "shell lint"
+  fi
+fi
+
+if [[ ${#workflow_lint_targets[@]} -gt 0 ]]; then
+  if command -v actionlint > /dev/null 2>&1; then
+    run_check "workflow lint (${#workflow_lint_targets[@]} file(s))" tools/workflow_lint.sh -- "${workflow_lint_targets[@]}"
+  else
+    mark_missing_tool "actionlint" "workflow lint"
+  fi
+fi
+
+if [[ ${#workflow_security_targets[@]} -gt 0 ]]; then
+  if command -v zizmor > /dev/null 2>&1; then
+    run_check "zizmor workflow security" tools/zizmor.sh
+  else
+    mark_missing_tool "zizmor" "workflow security analysis"
+  fi
+fi
+
+if [[ ${#dependency_scan_targets[@]} -gt 0 ]]; then
+  if command -v osv-scanner > /dev/null 2>&1 || command -v docker > /dev/null 2>&1; then
+    run_check "OSV dependency scan" tools/osv_scan.sh
+  else
+    mark_missing_tool "osv-scanner/docker" "OSV dependency scan"
+  fi
+fi
+
+if command -v lizard > /dev/null 2>&1; then
   run_check "Lizard complexity (src/include)" tools/lizard.sh --strict
 else
   mark_missing_tool "lizard" "Lizard complexity analysis"
 fi
 
-if command -v scan-build >/dev/null 2>&1; then
-  run_check "scan-build strict (full rebuild)" tools/scan_build.sh --strict
+if [[ "$RUN_SCAN_BUILD" == "1" ]]; then
+  if command -v scan-build > /dev/null 2>&1; then
+    run_check "scan-build strict (full rebuild)" tools/scan_build.sh --strict
+  else
+    mark_missing_tool "scan-build" "scan-build analysis"
+  fi
 else
-  mark_missing_tool "scan-build" "scan-build analysis"
+  echo "pre-push: skipping scan-build full rebuild (set MBE_HOOK_RUN_SCAN_BUILD=1 to enable)."
 fi
 
 if [[ ${#missing_tools[@]} -gt 0 ]]; then

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+* @arancormonk
+
+/CMakeLists.txt @arancormonk
+/CMakePresets.json @arancormonk
+/.github/ @arancormonk
+/cmake/ @arancormonk
+/tools/ @arancormonk
+
+/include/mbelib-neo/ @arancormonk
+/src/ @arancormonk
+/tests/ @arancormonk

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,8 @@
 name: "mbelib-neo CodeQL config"
 
+queries:
+  - uses: security-and-quality
+
 # Keep vendored upstream libraries out of project-owned CodeQL results.
 paths-ignore:
   - "src/external/**"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      # Optional: day/time can be set to reduce noise
-      # day: "monday"
-      # time: "09:00"
-      # timezone: "UTC"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github_actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+- 
+
+## Review
+
+- [ ] Changes were reviewed against the surrounding module design.
+- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
+- [ ] Risky or broad changes have a second reviewer.
+- [ ] Copied, generated, or bulk-written code has been read, understood, and adapted to mbelib-neo conventions.
+
+## Quality Review
+
+- [ ] New decoder, file input, allocator, threading, dependency, or public API changes include focused tests.
+- [ ] Codec, DSP, workflow, dependency, and release changes received extra scrutiny.
+- [ ] Static-analysis suppressions include a reason and are limited to the narrowest scope.
+- [ ] No new direct bundled-third-party includes, shell execution, broad workflow permissions, or release publishing paths were added without justification.
+
+## Tests And Guardrails
+
+- [ ] `cmake --build --preset dev-debug -j`
+- [ ] `ctest --preset dev-debug --output-on-failure`
+- [ ] `tools/preflight_ci.sh`
+- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
+- [ ] `tools/cmake_format_check.sh` for CMake changes
+- [ ] `tools/zizmor.sh` for workflow changes
+- [ ] `tools/osv_scan.sh` for dependency input changes
+
+## Risk
+
+- Security/dependency impact:
+- API/ABI compatibility impact:
+- Packaging/release impact:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         preset: [dev-debug, dev-release, notones-debug]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure (${{ matrix.preset }})
         run: cmake --preset ${{ matrix.preset }}
       - name: Build (${{ matrix.preset }})
@@ -40,7 +40,7 @@ jobs:
     name: linux • Debug • sanitizers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure (asan-ubsan-debug)
         run: cmake --preset asan-ubsan-debug
       - name: Build (asan-ubsan-debug)
@@ -55,7 +55,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check formatting
         run: |
           bash tools/ci_arch_toolchain.sh bash -lc '
@@ -75,21 +75,21 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compute IWYU toolchain SHA
         id: iwyu-sha
         run: |
           set -euxo pipefail
           echo "sha=$(git ls-remote https://github.com/include-what-you-use/include-what-you-use refs/heads/clang_22 | cut -f1)" >> "$GITHUB_OUTPUT"
       - name: Restore Arch toolchain cache
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .deps-arch-toolchain
           key: arch-toolchain-${{ runner.os }}-iwyu-${{ steps.iwyu-sha.outputs.sha }}
           restore-keys: |
             arch-toolchain-${{ runner.os }}-iwyu-
       - name: Restore ccache
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ccache
           key: ccache-${{ runner.os }}-arch-${{ github.job }}-${{ github.sha }}
@@ -117,7 +117,7 @@ jobs:
           '
       - name: Upload clang-tidy output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: clang-tidy-report
           path: .clang-tidy.local.out
@@ -125,7 +125,7 @@ jobs:
           retention-days: 7
       - name: Upload IWYU output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: iwyu-report
           path: .iwyu.local.out
@@ -133,7 +133,7 @@ jobs:
           retention-days: 7
       - name: Upload GCC fanalyzer output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gcc-fanalyzer-report
           path: .gcc-fanalyzer.local.out
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run cppcheck under Arch toolchain
         run: |
@@ -156,7 +156,7 @@ jobs:
           '
       - name: Upload cppcheck output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cppcheck-report
           path: .cppcheck.local.out
@@ -168,13 +168,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run scan-build under Arch toolchain
         run: |
           bash tools/ci_arch_toolchain.sh tools/scan_build.sh --strict
       - name: Upload scan-build output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scan-build-report
           path: |
@@ -187,22 +187,35 @@ jobs:
     name: semgrep
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - name: Install Semgrep
         run: python -m pip install --upgrade semgrep
       - name: Run Semgrep
+        env:
+          MBE_SEMGREP_SARIF_OUT: .semgrep.sarif
         run: tools/semgrep.sh --strict
+      - name: Upload Semgrep SARIF
+        if: always() && hashFiles('.semgrep.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: .semgrep.sarif
       - name: Upload Semgrep output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: semgrep-report
-          path: .semgrep.local.out
+          path: |
+            .semgrep.local.out
+            .semgrep.sarif
           include-hidden-files: true
           retention-days: 7
 
@@ -211,9 +224,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - name: Install Lizard
@@ -222,7 +235,7 @@ jobs:
         run: tools/lizard.sh --strict
       - name: Upload Lizard output
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lizard-report
           path: .lizard.local.out
@@ -237,7 +250,7 @@ jobs:
       version: ${{ steps.verify.outputs.version }}
       archive_prefix: ${{ steps.verify.outputs.archive_prefix }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure release metadata
         run: cmake --preset dev-release -DMBELIB_BUILD_TESTS=OFF -DMBELIB_BUILD_EXAMPLES=OFF
       - name: Verify tag matches project version
@@ -328,7 +341,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.aur_key.outputs.has_key == 'true'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -472,7 +485,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.aur_key.outputs.has_key == 'true'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -567,7 +580,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Ensure pkg-config is available (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y pkg-config
@@ -626,7 +639,7 @@ jobs:
     name: install + consume (CMake, Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure (dev-release preset)
         run: cmake --preset dev-release
       - name: Build (dev-release preset)
@@ -672,7 +685,7 @@ jobs:
           - os: macos-latest
           - os: windows-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure (dev-release preset)
         run: cmake --preset dev-release
       - name: Build (dev-release preset)
@@ -742,14 +755,14 @@ jobs:
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
       - name: Upload release package (Unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-${{ runner.os }}-${{ runner.arch }}
           path: ${{ steps.package_unix.outputs.archive_path }}
           retention-days: 7
       - name: Upload release package (Windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-${{ runner.os }}-${{ runner.arch }}
           path: ${{ steps.package_windows.outputs.archive_path }}
@@ -764,7 +777,7 @@ jobs:
       contents: write
     steps:
       - name: Download packaged artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           pattern: release-package-*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,28 +26,36 @@ jobs:
       matrix:
         include:
           - language: c-cpp
-            build-mode: none
+            build-mode: manual
           - language: actions
             build-mode: ""
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         if: matrix.build-mode == ''
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Initialize CodeQL with build mode
         if: matrix.build-mode != ''
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
+      - name: Configure C/C++ database build
+        if: matrix.language == 'c-cpp'
+        run: cmake --preset dev-debug
+
+      - name: Build C/C++ database
+        if: matrix.language == 'c-cpp'
+        run: cmake --build --preset dev-debug -j
+
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,0 +1,270 @@
+name: guardrails
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "19 6 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  script-lint:
+    name: shell/workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run shell and workflow lint
+        env:
+          CI_ARCH_EXTRA_PACKAGES: shellcheck shfmt actionlint
+        run: |
+          tools/ci_arch_toolchain.sh bash -lc '
+            set -euo pipefail
+            tools/shell_lint.sh
+            tools/workflow_lint.sh
+          '
+
+      - name: Upload lint output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: script-lint-report
+          path: |
+            .shell-lint.local.out
+            .actionlint.local.out
+          include-hidden-files: true
+          retention-days: 7
+
+  cmake-format:
+    name: cmake format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute PR changed files
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          tools/ci_changed_files.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head HEAD \
+            --no-header-expansion
+
+      - name: Skip CMake format
+        if: github.event_name == 'pull_request' && steps.changed.outputs.cmake_format_files == '0'
+        run: echo "No CMake files to check."
+
+      - name: Set up Python
+        if: github.event_name != 'pull_request' || steps.changed.outputs.cmake_format_files != '0'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Install gersemi
+        if: github.event_name != 'pull_request' || steps.changed.outputs.cmake_format_files != '0'
+        run: python -m pip install --upgrade gersemi
+
+      - name: Check CMake formatting
+        if: github.event_name != 'pull_request' || steps.changed.outputs.cmake_format_files != '0'
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            mapfile -t files < .ci/changed-files/cmake_format_files.txt
+            tools/cmake_format_check.sh -- "${files[@]}"
+          else
+            tools/cmake_format_check.sh
+          fi
+
+      - name: Upload CMake format output
+        if: always() && (github.event_name != 'pull_request' || steps.changed.outputs.cmake_format_files != '0')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmake-format-report
+          path: .cmake-format.local.out
+          include-hidden-files: true
+          retention-days: 7
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        run: tools/gitleaks.sh
+
+      - name: Upload Gitleaks SARIF
+        if: always() && hashFiles('.gitleaks.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: .gitleaks.sarif
+
+      - name: Upload Gitleaks output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-report
+          path: |
+            .gitleaks.local.out
+            .gitleaks.sarif
+          include-hidden-files: true
+          retention-days: 7
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute PR changed files
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          tools/ci_changed_files.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head HEAD \
+            --no-header-expansion
+
+      - name: Skip zizmor
+        if: github.event_name == 'pull_request' && steps.changed.outputs.workflow_security_targets == '0'
+        run: echo "No workflow security files to check."
+
+      - name: Set up Python
+        if: github.event_name != 'pull_request' || steps.changed.outputs.workflow_security_targets != '0'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Install zizmor
+        if: github.event_name != 'pull_request' || steps.changed.outputs.workflow_security_targets != '0'
+        run: python -m pip install --upgrade zizmor
+
+      - name: Run zizmor
+        if: github.event_name != 'pull_request' || steps.changed.outputs.workflow_security_targets != '0'
+        env:
+          MBE_ZIZMOR_SARIF_OUT: .zizmor.sarif
+        run: tools/zizmor.sh
+
+      - name: Run pedantic zizmor advisory
+        if: github.event_name == 'schedule'
+        continue-on-error: true
+        env:
+          MBE_ZIZMOR_SARIF_OUT: .zizmor-pedantic.sarif
+        run: tools/zizmor.sh --pedantic --min-confidence high --no-config
+
+      - name: Upload zizmor SARIF
+        if: always() && hashFiles('.zizmor.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: .zizmor.sarif
+
+      - name: Upload zizmor output
+        if: always() && (github.event_name != 'pull_request' || steps.changed.outputs.workflow_security_targets != '0')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zizmor-report
+          path: |
+            .zizmor.local.out
+            .zizmor.sarif
+            .zizmor-pedantic.sarif
+          include-hidden-files: true
+          retention-days: 7
+
+  osv-scan:
+    name: osv scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute PR changed files
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          tools/ci_changed_files.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head HEAD \
+            --no-header-expansion
+
+      - name: Skip OSV scan
+        if: github.event_name == 'pull_request' && steps.changed.outputs.dependency_scan_targets == '0'
+        run: echo "No dependency inputs to scan."
+
+      - name: Run OSV scan
+        if: github.event_name != 'pull_request' || steps.changed.outputs.dependency_scan_targets != '0'
+        env:
+          MBE_OSV_SARIF_OUT: .osv-scanner.sarif
+        run: tools/osv_scan.sh
+
+      - name: Upload OSV SARIF
+        if: always() && hashFiles('.osv-scanner.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: .osv-scanner.sarif
+
+      - name: Upload OSV output
+        if: always() && (github.event_name != 'pull_request' || steps.changed.outputs.dependency_scan_targets != '0')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osv-scan-report
+          path: |
+            .osv-scanner.local.out
+            .osv-scanner.sarif
+          include-hidden-files: true
+          retention-days: 7
+
+  dependency-review:
+    name: dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: always
+
+  warnings-as-errors:
+    name: warnings as errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure with warnings as errors
+        run: cmake --preset dev-debug -DMBELIB_WARNINGS_AS_ERRORS=ON
+
+      - name: Build with warnings as errors
+        run: cmake --build --preset dev-debug -j
+
+      - name: Test warnings-as-errors build
+        run: ctest --preset dev-debug --output-on-failure

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: scorecard
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "37 5 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard SARIF
+        if: always() && hashFiles('scorecard.sarif') != ''
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: scorecard.sarif
+
+      - name: Upload Scorecard output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-report
+          path: scorecard.sarif
+          include-hidden-files: true
+          retention-days: 7

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  # External actions must be pinned to immutable commit SHAs.
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Tool caches
 /.cache/
 /.ccache/
+/.ci/
 /.deps/
 /.deps-arch-toolchain/
 
@@ -17,10 +18,18 @@ Thumbs.db
 # Ignore all markdown files in root directory with exceptions
 /*.md
 !/README.md
+!/SECURITY.md
 
 # Log files
 /logs/
 *.log
 *.out
+/.cmake-format.local.out
+/.gitleaks.sarif
+/.osv-scanner.local.out
+/.osv-scanner.sarif
+/.zizmor.local.out
+/.zizmor.sarif
+/.zizmor-pedantic.sarif
 /.scan-build.local/
 /.cppcheck-build/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "mbelib-neo Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Repository public keys and non-secret test fixtures"
+paths = [
+  '''^mbelib_Author\.pgp$''',
+]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,22 +10,26 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(CheckCSourceCompiles)
 
 function(_mbelib_check_c_source_compiles_static source out_var)
-  set(_mbelib_had_try_compile_target_type OFF)
-  if(DEFINED CMAKE_TRY_COMPILE_TARGET_TYPE)
-    set(_mbelib_had_try_compile_target_type ON)
-    set(_mbelib_saved_try_compile_target_type "${CMAKE_TRY_COMPILE_TARGET_TYPE}")
-  endif()
+    set(_mbelib_had_try_compile_target_type OFF)
+    if(DEFINED CMAKE_TRY_COMPILE_TARGET_TYPE)
+        set(_mbelib_had_try_compile_target_type ON)
+        set(_mbelib_saved_try_compile_target_type
+            "${CMAKE_TRY_COMPILE_TARGET_TYPE}"
+        )
+    endif()
 
-  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-  check_c_source_compiles("${source}" ${out_var})
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+    check_c_source_compiles("${source}" ${out_var})
 
-  if(_mbelib_had_try_compile_target_type)
-    set(CMAKE_TRY_COMPILE_TARGET_TYPE "${_mbelib_saved_try_compile_target_type}")
-  else()
-    unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
-  endif()
+    if(_mbelib_had_try_compile_target_type)
+        set(CMAKE_TRY_COMPILE_TARGET_TYPE
+            "${_mbelib_saved_try_compile_target_type}"
+        )
+    else()
+        unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
+    endif()
 
-  set(${out_var} "${${out_var}}" PARENT_SCOPE)
+    set(${out_var} "${${out_var}}" PARENT_SCOPE)
 endfunction()
 
 # Options
@@ -34,44 +38,61 @@ option(MBELIB_BUILD_TESTS "Build mbelib tests" ON)
 option(MBELIB_BUILD_EXAMPLES "Build examples" ON)
 option(MBELIB_BUILD_DOCS "Generate API docs with Doxygen" OFF)
 option(MBELIB_ENABLE_ASAN "Enable AddressSanitizer in Debug builds" OFF)
-option(MBELIB_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer in Debug builds" OFF)
+option(
+    MBELIB_ENABLE_UBSAN
+    "Enable UndefinedBehaviorSanitizer in Debug builds"
+    OFF
+)
 option(MBE_ENABLE_DEBUG_LOGS "Enable debug logging in codec sources" OFF)
 option(MBELIB_ENABLE_WARNINGS "Enable common warning flags" ON)
 option(MBELIB_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
-option(MBELIB_ENABLE_FAST_MATH "Enable fast-math optimizations (may relax IEEE semantics)" OFF)
-option(MBELIB_ENABLE_LTO "Enable Link Time Optimization (IPO/LTO) for Release builds" OFF)
-option(MBELIB_ENABLE_SIMD "Enable SIMD optimized routines when available (SSE2/NEON)" OFF)
+option(
+    MBELIB_ENABLE_FAST_MATH
+    "Enable fast-math optimizations (may relax IEEE semantics)"
+    OFF
+)
+option(
+    MBELIB_ENABLE_LTO
+    "Enable Link Time Optimization (IPO/LTO) for Release builds"
+    OFF
+)
+option(
+    MBELIB_ENABLE_SIMD
+    "Enable SIMD optimized routines when available (SSE2/NEON)"
+    OFF
+)
 option(MBELIB_BUILD_BENCHMARKS "Build micro-benchmarks (not run in CI)" OFF)
-option(MBELIB_STRICT_ORDER "Reserved compatibility flag (currently no behavior change)" OFF)
+option(
+    MBELIB_STRICT_ORDER
+    "Reserved compatibility flag (currently no behavior change)"
+    OFF
+)
 
 # Generated headers (version)
 include(CMakePackageConfigHelpers)
 set(MBELIB_GENERATED_INCLUDE_DIR "${PROJECT_BINARY_DIR}/include")
 configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/mbelib-neo/version.h.in"
-  "${MBELIB_GENERATED_INCLUDE_DIR}/mbelib-neo/version.h"
-  @ONLY
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/mbelib-neo/version.h.in"
+    "${MBELIB_GENERATED_INCLUDE_DIR}/mbelib-neo/version.h"
+    @ONLY
 )
 
 # PFFFT sources (bundled, BSD-like FFTPACK license)
-set(PFFFT_SOURCES
-  src/external/pffft/pffft.c
-  src/external/pffft/fftpack.c
-)
+set(PFFFT_SOURCES src/external/pffft/pffft.c src/external/pffft/fftpack.c)
 
 # Explicit source list (avoids FILE(GLOB ...))
 set(MBELIB_SOURCES
-  src/ambe/ambe3600x2400.c
-  src/ambe/ambe3600x2450.c
-  src/ambe/ambe_common.c
-  src/ecc/ecc.c
-  src/ecc/ecc_const.c
-  src/imbe/imbe7100x4400.c
-  src/imbe/imbe7200x4400.c
-  src/core/mbelib.c
-  src/core/mbe_adaptive.c
-  src/core/mbe_unvoiced_fft.c
-  ${PFFFT_SOURCES}
+    src/ambe/ambe3600x2400.c
+    src/ambe/ambe3600x2450.c
+    src/ambe/ambe_common.c
+    src/ecc/ecc.c
+    src/ecc/ecc_const.c
+    src/imbe/imbe7100x4400.c
+    src/imbe/imbe7200x4400.c
+    src/core/mbelib.c
+    src/core/mbe_adaptive.c
+    src/core/mbe_unvoiced_fft.c
+    ${PFFFT_SOURCES}
 )
 
 add_library(mbe-shared SHARED ${MBELIB_SOURCES})
@@ -82,25 +103,27 @@ add_library(mbe_neo::mbe_static ALIAS mbe-static)
 
 target_compile_definitions(mbe-shared PRIVATE MBE_BUILDING=1)
 
-target_include_directories(mbe-shared
-  PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${MBELIB_GENERATED_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include>
-  PRIVATE
-    ${PROJECT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/src/internal
-    ${PROJECT_SOURCE_DIR}/src/external/pffft
+target_include_directories(
+    mbe-shared
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${MBELIB_GENERATED_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src/internal
+        ${PROJECT_SOURCE_DIR}/src/external/pffft
 )
-target_include_directories(mbe-static
-  PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${MBELIB_GENERATED_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include>
-  PRIVATE
-    ${PROJECT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/src/internal
-    ${PROJECT_SOURCE_DIR}/src/external/pffft
+target_include_directories(
+    mbe-static
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${MBELIB_GENERATED_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src/internal
+        ${PROJECT_SOURCE_DIR}/src/external/pffft
 )
 
 # Mark static consumption for Windows to avoid dllimport decorations in headers
@@ -108,75 +131,84 @@ target_compile_definitions(mbe-static PUBLIC MBE_STATIC=1)
 
 # Optional verbose debug logging in library sources
 if(MBE_ENABLE_DEBUG_LOGS)
-  target_compile_definitions(mbe-shared PRIVATE MBE_DEBUG IMBE_DEBUG AMBE_DEBUG)
-  target_compile_definitions(mbe-static PRIVATE MBE_DEBUG IMBE_DEBUG AMBE_DEBUG)
+    target_compile_definitions(
+        mbe-shared
+        PRIVATE MBE_DEBUG IMBE_DEBUG AMBE_DEBUG
+    )
+    target_compile_definitions(
+        mbe-static
+        PRIVATE MBE_DEBUG IMBE_DEBUG AMBE_DEBUG
+    )
 endif()
 
 # Target-scoped compile definitions
 if(NOTONES)
-  target_compile_definitions(mbe-shared PRIVATE DISABLE_AMBE_TONES)
-  target_compile_definitions(mbe-static PRIVATE DISABLE_AMBE_TONES)
+    target_compile_definitions(mbe-shared PRIVATE DISABLE_AMBE_TONES)
+    target_compile_definitions(mbe-static PRIVATE DISABLE_AMBE_TONES)
 endif()
 if(MBELIB_STRICT_ORDER)
-  target_compile_definitions(mbe-shared PRIVATE MBELIB_STRICT_ORDER=1)
-  target_compile_definitions(mbe-static PRIVATE MBELIB_STRICT_ORDER=1)
+    target_compile_definitions(mbe-shared PRIVATE MBELIB_STRICT_ORDER=1)
+    target_compile_definitions(mbe-static PRIVATE MBELIB_STRICT_ORDER=1)
 endif()
 
 # Documentation (Doxygen)
 if(MBELIB_BUILD_DOCS)
-  find_package(Doxygen QUIET)
-  if(DOXYGEN_FOUND)
-    add_custom_target(docs
-      COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMENT "Generating API documentation with Doxygen"
-      VERBATIM)
-  else()
-    message(STATUS "Doxygen not found; docs target will not be available.")
-  endif()
+    find_package(Doxygen QUIET)
+    if(DOXYGEN_FOUND)
+        add_custom_target(
+            docs
+            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Generating API documentation with Doxygen"
+            VERBATIM
+        )
+    else()
+        message(STATUS "Doxygen not found; docs target will not be available.")
+    endif()
 endif()
 
 if(MSVC)
-  target_compile_definitions(mbe-shared PRIVATE _USE_MATH_DEFINES)
-  target_compile_definitions(mbe-static PRIVATE _USE_MATH_DEFINES)
+    target_compile_definitions(mbe-shared PRIVATE _USE_MATH_DEFINES)
+    target_compile_definitions(mbe-static PRIVATE _USE_MATH_DEFINES)
 endif()
 
 # Warnings
 if(MBELIB_ENABLE_WARNINGS)
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-    target_compile_options(mbe-shared PRIVATE -Wall -Wextra -Wpedantic)
-    target_compile_options(mbe-static PRIVATE -Wall -Wextra -Wpedantic)
-    if(MBELIB_WARNINGS_AS_ERRORS)
-      target_compile_options(mbe-shared PRIVATE -Werror)
-      target_compile_options(mbe-static PRIVATE -Werror)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(mbe-shared PRIVATE -Wall -Wextra -Wpedantic)
+        target_compile_options(mbe-static PRIVATE -Wall -Wextra -Wpedantic)
+        if(MBELIB_WARNINGS_AS_ERRORS)
+            target_compile_options(mbe-shared PRIVATE -Werror)
+            target_compile_options(mbe-static PRIVATE -Werror)
+        endif()
+    elseif(MSVC)
+        target_compile_options(mbe-shared PRIVATE /W4)
+        target_compile_options(mbe-static PRIVATE /W4)
+        if(MBELIB_WARNINGS_AS_ERRORS)
+            target_compile_options(mbe-shared PRIVATE /WX)
+            target_compile_options(mbe-static PRIVATE /WX)
+        endif()
     endif()
-  elseif(MSVC)
-    target_compile_options(mbe-shared PRIVATE /W4)
-    target_compile_options(mbe-static PRIVATE /W4)
-    if(MBELIB_WARNINGS_AS_ERRORS)
-      target_compile_options(mbe-shared PRIVATE /WX)
-      target_compile_options(mbe-static PRIVATE /WX)
-    endif()
-  endif()
 endif()
 
 if(NOT WIN32)
-  target_link_libraries(mbe-static m)
-  target_link_libraries(mbe-shared m)
+    target_link_libraries(mbe-static m)
+    target_link_libraries(mbe-shared m)
 endif()
 
 # Detect 32-bit x86 targets so the SIMD option can ensure SSE2 codegen when
 # needed instead of relying on the host processor string.
 set(MBELIB_TARGET_X86_32 OFF)
 set(_mbelib_x86_32_probe_source
-  [=[
+    [=[
     #if !defined(__i386__) && !defined(_M_IX86)
     #error Not a 32-bit x86 target
     #endif
     int mbelib_target_x86_32;
-  ]=])
+  ]=]
+)
 set(_mbelib_x86_32_sse2_probe_source
-  [=[
+    [=[
     #if !defined(__i386__) && !defined(_M_IX86)
     #error Not a 32-bit x86 target
     #endif
@@ -184,127 +216,159 @@ set(_mbelib_x86_32_sse2_probe_source
     #error 32-bit x86 target is not compiling for SSE2
     #endif
     int mbelib_target_x86_32_sse2;
-  ]=])
+  ]=]
+)
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-  # Query the active compiler target instead of the host processor string so
-  # multilib builds (for example -m32 on an x86_64 host) are classified
-  # correctly during configure.
-  _mbelib_check_c_source_compiles_static("${_mbelib_x86_32_probe_source}" _mbelib_compiler_targets_x86_32)
-  if(_mbelib_compiler_targets_x86_32)
-    set(MBELIB_TARGET_X86_32 ON)
-  endif()
-  unset(_mbelib_compiler_targets_x86_32 CACHE)
-  unset(_mbelib_compiler_targets_x86_32)
+    # Query the active compiler target instead of the host processor string so
+    # multilib builds (for example -m32 on an x86_64 host) are classified
+    # correctly during configure.
+    _mbelib_check_c_source_compiles_static("${_mbelib_x86_32_probe_source}" _mbelib_compiler_targets_x86_32)
+    if(_mbelib_compiler_targets_x86_32)
+        set(MBELIB_TARGET_X86_32 ON)
+    endif()
+    unset(_mbelib_compiler_targets_x86_32 CACHE)
+    unset(_mbelib_compiler_targets_x86_32)
 endif()
 
 # Optional SIMD toggles
 if(MBELIB_ENABLE_SIMD)
-  target_compile_definitions(mbe-shared PRIVATE MBELIB_ENABLE_SIMD=1)
-  target_compile_definitions(mbe-static PRIVATE MBELIB_ENABLE_SIMD=1)
-  if(MBELIB_TARGET_X86_32)
-    set(_mbelib_x86_sse2_flag "")
-    _mbelib_check_c_source_compiles_static("${_mbelib_x86_32_sse2_probe_source}" _mbelib_x86_targets_sse2_by_default)
-    if(_mbelib_x86_targets_sse2_by_default)
-      message(STATUS "MBELIB_ENABLE_SIMD on 32-bit x86: active compiler target already includes SSE2")
-    else()
-      set(_mbelib_x86_sse2_candidate_flags -msse2 /arch:SSE2)
-      if(MSVC)
-        set(_mbelib_x86_sse2_candidate_flags /arch:SSE2 -msse2)
-      endif()
-
-      foreach(_mbelib_candidate_flag IN LISTS _mbelib_x86_sse2_candidate_flags)
-        set(_mbelib_saved_required_flags "${CMAKE_REQUIRED_FLAGS}")
-        if(CMAKE_REQUIRED_FLAGS)
-          set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${_mbelib_candidate_flag}")
+    target_compile_definitions(mbe-shared PRIVATE MBELIB_ENABLE_SIMD=1)
+    target_compile_definitions(mbe-static PRIVATE MBELIB_ENABLE_SIMD=1)
+    if(MBELIB_TARGET_X86_32)
+        set(_mbelib_x86_sse2_flag "")
+        _mbelib_check_c_source_compiles_static("${_mbelib_x86_32_sse2_probe_source}" _mbelib_x86_targets_sse2_by_default)
+        if(_mbelib_x86_targets_sse2_by_default)
+            message(
+                STATUS
+                "MBELIB_ENABLE_SIMD on 32-bit x86: active compiler target already includes SSE2"
+            )
         else()
-          set(CMAKE_REQUIRED_FLAGS "${_mbelib_candidate_flag}")
+            set(_mbelib_x86_sse2_candidate_flags -msse2 /arch:SSE2)
+            if(MSVC)
+                set(_mbelib_x86_sse2_candidate_flags /arch:SSE2 -msse2)
+            endif()
+
+            foreach(
+                _mbelib_candidate_flag
+                IN
+                LISTS _mbelib_x86_sse2_candidate_flags
+            )
+                set(_mbelib_saved_required_flags "${CMAKE_REQUIRED_FLAGS}")
+                if(CMAKE_REQUIRED_FLAGS)
+                    set(CMAKE_REQUIRED_FLAGS
+                        "${CMAKE_REQUIRED_FLAGS} ${_mbelib_candidate_flag}"
+                    )
+                else()
+                    set(CMAKE_REQUIRED_FLAGS "${_mbelib_candidate_flag}")
+                endif()
+
+                _mbelib_check_c_source_compiles_static(
+                  "${_mbelib_x86_32_sse2_probe_source}"
+                  _mbelib_x86_sse2_candidate_supported
+                )
+
+                set(CMAKE_REQUIRED_FLAGS "${_mbelib_saved_required_flags}")
+                set(_mbelib_candidate_flag_supported
+                    "${_mbelib_x86_sse2_candidate_supported}"
+                )
+                unset(_mbelib_x86_sse2_candidate_supported CACHE)
+                unset(_mbelib_x86_sse2_candidate_supported)
+
+                if(_mbelib_candidate_flag_supported)
+                    set(_mbelib_x86_sse2_flag "${_mbelib_candidate_flag}")
+                    break()
+                endif()
+            endforeach()
+
+            if(NOT _mbelib_x86_sse2_flag)
+                message(
+                    FATAL_ERROR
+                    "MBELIB_ENABLE_SIMD on 32-bit x86 requires the active compiler target to enable SSE2 "
+                    "(for example via -msse2 or /arch:SSE2)"
+                )
+            endif()
+
+            message(
+                STATUS
+                "MBELIB_ENABLE_SIMD on 32-bit x86: compiling library targets for SSE2 via ${_mbelib_x86_sse2_flag}"
+            )
+            target_compile_options(mbe-shared PRIVATE ${_mbelib_x86_sse2_flag})
+            target_compile_options(mbe-static PRIVATE ${_mbelib_x86_sse2_flag})
         endif()
-
-        _mbelib_check_c_source_compiles_static(
-          "${_mbelib_x86_32_sse2_probe_source}"
-          _mbelib_x86_sse2_candidate_supported)
-
-        set(CMAKE_REQUIRED_FLAGS "${_mbelib_saved_required_flags}")
-        set(_mbelib_candidate_flag_supported "${_mbelib_x86_sse2_candidate_supported}")
-        unset(_mbelib_x86_sse2_candidate_supported CACHE)
-        unset(_mbelib_x86_sse2_candidate_supported)
-
-        if(_mbelib_candidate_flag_supported)
-          set(_mbelib_x86_sse2_flag "${_mbelib_candidate_flag}")
-          break()
-        endif()
-      endforeach()
-
-      if(NOT _mbelib_x86_sse2_flag)
-        message(FATAL_ERROR
-          "MBELIB_ENABLE_SIMD on 32-bit x86 requires the active compiler target to enable SSE2 "
-          "(for example via -msse2 or /arch:SSE2)")
-      endif()
-
-      message(STATUS "MBELIB_ENABLE_SIMD on 32-bit x86: compiling library targets for SSE2 via ${_mbelib_x86_sse2_flag}")
-      target_compile_options(mbe-shared PRIVATE ${_mbelib_x86_sse2_flag})
-      target_compile_options(mbe-static PRIVATE ${_mbelib_x86_sse2_flag})
+        unset(_mbelib_x86_sse2_candidate_flags)
+        unset(_mbelib_x86_targets_sse2_by_default CACHE)
+        unset(_mbelib_x86_targets_sse2_by_default)
+        unset(_mbelib_x86_sse2_flag)
+        unset(_mbelib_candidate_flag)
+        unset(_mbelib_candidate_flag_supported)
+        unset(_mbelib_saved_required_flags)
     endif()
-    unset(_mbelib_x86_sse2_candidate_flags)
-    unset(_mbelib_x86_targets_sse2_by_default CACHE)
-    unset(_mbelib_x86_targets_sse2_by_default)
-    unset(_mbelib_x86_sse2_flag)
-    unset(_mbelib_candidate_flag)
-    unset(_mbelib_candidate_flag_supported)
-    unset(_mbelib_saved_required_flags)
-  endif()
 else()
-  # Keep bundled PFFFT scalar when SIMD is disabled for the project.
-  target_compile_definitions(mbe-shared PRIVATE PFFFT_SIMD_DISABLE=1)
-  target_compile_definitions(mbe-static PRIVATE PFFFT_SIMD_DISABLE=1)
+    # Keep bundled PFFFT scalar when SIMD is disabled for the project.
+    target_compile_definitions(mbe-shared PRIVATE PFFFT_SIMD_DISABLE=1)
+    target_compile_definitions(mbe-static PRIVATE PFFFT_SIMD_DISABLE=1)
 endif()
 
 # Fast-math (optional)
 if(MBELIB_ENABLE_FAST_MATH)
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-    target_compile_options(mbe-shared PRIVATE -ffast-math -fno-math-errno)
-    target_compile_options(mbe-static PRIVATE -ffast-math -fno-math-errno)
-  elseif(MSVC)
-    target_compile_options(mbe-shared PRIVATE /fp:fast)
-    target_compile_options(mbe-static PRIVATE /fp:fast)
-  endif()
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(mbe-shared PRIVATE -ffast-math -fno-math-errno)
+        target_compile_options(mbe-static PRIVATE -ffast-math -fno-math-errno)
+    elseif(MSVC)
+        target_compile_options(mbe-shared PRIVATE /fp:fast)
+        target_compile_options(mbe-static PRIVATE /fp:fast)
+    endif()
 endif()
 
 # Sanitizers (Debug builds only)
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  # Collect sanitizer flags once and apply to libraries and executables (tests/examples)
-  # so the sanitizer runtimes are linked into the final executables.
-  set(_mbelib_san_cflags "")
-  set(_mbelib_san_ldflags "")
-  if(MBELIB_ENABLE_ASAN AND (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU"))
-    list(APPEND _mbelib_san_cflags -fsanitize=address -fno-omit-frame-pointer)
-    # For Clang, enable stronger detection of stack use-after-scope
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      list(APPEND _mbelib_san_cflags -fsanitize-address-use-after-scope)
+    # Collect sanitizer flags once and apply to libraries and executables (tests/examples)
+    # so the sanitizer runtimes are linked into the final executables.
+    set(_mbelib_san_cflags "")
+    set(_mbelib_san_ldflags "")
+    if(MBELIB_ENABLE_ASAN AND (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU"))
+        list(
+            APPEND _mbelib_san_cflags
+            -fsanitize=address
+            -fno-omit-frame-pointer
+        )
+        # For Clang, enable stronger detection of stack use-after-scope
+        if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+            list(APPEND _mbelib_san_cflags -fsanitize-address-use-after-scope)
+        endif()
+        list(APPEND _mbelib_san_ldflags -fsanitize=address)
     endif()
-    list(APPEND _mbelib_san_ldflags -fsanitize=address)
-  endif()
-  if(MBELIB_ENABLE_UBSAN AND (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU"))
-    list(APPEND _mbelib_san_cflags -fsanitize=undefined -fno-sanitize-recover=undefined)
-    list(APPEND _mbelib_san_ldflags -fsanitize=undefined)
-  endif()
+    if(MBELIB_ENABLE_UBSAN AND (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU"))
+        list(
+            APPEND _mbelib_san_cflags
+            -fsanitize=undefined
+            -fno-sanitize-recover=undefined
+        )
+        list(APPEND _mbelib_san_ldflags -fsanitize=undefined)
+    endif()
 
-  if(_mbelib_san_cflags OR _mbelib_san_ldflags)
-    # Apply to core libraries first
-    foreach(tgt IN ITEMS mbe-shared mbe-static)
-      if(_mbelib_san_cflags)
-        target_compile_options(${tgt} PRIVATE ${_mbelib_san_cflags})
-      endif()
-      if(_mbelib_san_ldflags)
-        # Add sanitizer link flags before other options for correct ordering
-        target_link_options(${tgt} BEFORE PRIVATE ${_mbelib_san_ldflags})
-      endif()
-    endforeach()
-    # Stash the flags for later targets (tests/examples) via directory properties
-    set_directory_properties(PROPERTIES
-      MBELIB_SANITIZER_CFLAGS "${_mbelib_san_cflags}"
-      MBELIB_SANITIZER_LDFLAGS "${_mbelib_san_ldflags}")
-  endif()
+    if(_mbelib_san_cflags OR _mbelib_san_ldflags)
+        # Apply to core libraries first
+        foreach(tgt IN ITEMS mbe-shared mbe-static)
+            if(_mbelib_san_cflags)
+                target_compile_options(${tgt} PRIVATE ${_mbelib_san_cflags})
+            endif()
+            if(_mbelib_san_ldflags)
+                # Add sanitizer link flags before other options for correct ordering
+                target_link_options(
+                    ${tgt}
+                    BEFORE
+                    PRIVATE ${_mbelib_san_ldflags}
+                )
+            endif()
+        endforeach()
+        # Stash the flags for later targets (tests/examples) via directory properties
+        set_directory_properties(
+            PROPERTIES
+                MBELIB_SANITIZER_CFLAGS "${_mbelib_san_cflags}"
+                MBELIB_SANITIZER_LDFLAGS "${_mbelib_san_ldflags}"
+        )
+    endif()
 endif()
 
 include(GNUInstallDirs)
@@ -312,265 +376,410 @@ include(GNUInstallDirs)
 # On Windows, static and import libraries both use the .lib extension.
 # Give the static library a distinct name to avoid collisions during parallel builds.
 if(WIN32)
-  set(_MBELIB_STATIC_OUTPUT_NAME mbe-neo-static)
+    set(_MBELIB_STATIC_OUTPUT_NAME mbe-neo-static)
 else()
-  set(_MBELIB_STATIC_OUTPUT_NAME mbe-neo)
+    set(_MBELIB_STATIC_OUTPUT_NAME mbe-neo)
 endif()
 
-set_target_properties(mbe-static PROPERTIES
-  OUTPUT_NAME ${_MBELIB_STATIC_OUTPUT_NAME}
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
+set_target_properties(
+    mbe-static
+    PROPERTIES
+        OUTPUT_NAME ${_MBELIB_STATIC_OUTPUT_NAME}
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
 )
-set_target_properties(mbe-shared PROPERTIES
-  OUTPUT_NAME mbe-neo
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
-  C_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES
-  # On macOS, use @rpath so consumers control search paths at runtime
-  MACOSX_RPATH ON
-  INSTALL_NAME_DIR "@rpath"
+set_target_properties(
+    mbe-shared
+    PROPERTIES
+        OUTPUT_NAME mbe-neo
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        C_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN YES
+        # On macOS, use @rpath so consumers control search paths at runtime
+        MACOSX_RPATH ON
+        INSTALL_NAME_DIR "@rpath"
 )
 
 # Optional LTO/IPO
 if(MBELIB_ENABLE_LTO AND CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT _ipo_ok OUTPUT _ipo_msg)
-  if(_ipo_ok)
-    set_target_properties(mbe-static mbe-shared PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-  else()
-    message(STATUS "IPO/LTO not supported: ${_ipo_msg}")
-  endif()
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _ipo_ok OUTPUT _ipo_msg)
+    if(_ipo_ok)
+        set_target_properties(
+            mbe-static
+            mbe-shared
+            PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE
+        )
+    else()
+        message(STATUS "IPO/LTO not supported: ${_ipo_msg}")
+    endif()
 endif()
 
 # Generate pkg-config metadata
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmbe-neo.pc.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/libmbe-neo.pc" @ONLY)
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/libmbe-neo.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/libmbe-neo.pc"
+    @ONLY
+)
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libmbe-neo.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/libmbe-neo.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
 
-install(TARGETS mbe-static mbe-shared
-  EXPORT mbe-neoTargets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+    TARGETS mbe-static mbe-shared
+    EXPORT mbe-neoTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 # Install public headers (source) and generated headers
-install(FILES "${PROJECT_SOURCE_DIR}/include/mbelib-neo/mbelib.h"
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbelib-neo)
-install(FILES "${MBELIB_GENERATED_INCLUDE_DIR}/mbelib-neo/version.h"
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbelib-neo)
-install(FILES
+install(
+    FILES "${PROJECT_SOURCE_DIR}/include/mbelib-neo/mbelib.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbelib-neo
+)
+install(
+    FILES "${MBELIB_GENERATED_INCLUDE_DIR}/mbelib-neo/version.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbelib-neo
+)
+install(
+    FILES
         "${PROJECT_SOURCE_DIR}/LICENSE"
         "${PROJECT_SOURCE_DIR}/LICENSES/GPL-2.0-or-later.txt"
         "${PROJECT_SOURCE_DIR}/LICENSES/ISC.txt"
         "${PROJECT_SOURCE_DIR}/docs/upstream-mbelib-attribution.md"
-        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)
 
 # Exported targets and CMake package config
-install(EXPORT mbe-neoTargets
-        NAMESPACE mbe_neo::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo)
+install(
+    EXPORT mbe-neoTargets
+    NAMESPACE mbe_neo::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo
+)
 
 configure_package_config_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mbe-neoConfig.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfig.cmake"
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mbe-neoConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo
 )
 
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfigVersion.cmake"
-  VERSION ${PROJECT_VERSION}
-  COMPATIBILITY SameMajorVersion
+    "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
 )
 
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfig.cmake"
-  "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfigVersion.cmake"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo)
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/mbe-neoConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mbe-neo
+)
 
 # Choose link target for executables/tests: prefer shared; on Windows use static to avoid DLL path issues
 set(MBELIB_EXEC_LINK_TGT mbe-shared)
 if(WIN32)
-  set(MBELIB_EXEC_LINK_TGT mbe-static)
+    set(MBELIB_EXEC_LINK_TGT mbe-static)
 endif()
 
 # Examples
 if(MBELIB_BUILD_EXAMPLES)
-  add_executable(example_print_version examples/print_version.c)
-  target_link_libraries(example_print_version PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(example_print_version PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  # Propagate sanitizer flags to the example executable
-  get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
-  get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
-  if(_SAN_CFLAGS)
-    target_compile_options(example_print_version PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(example_print_version BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
+    add_executable(example_print_version examples/print_version.c)
+    target_link_libraries(example_print_version PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        example_print_version
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    # Propagate sanitizer flags to the example executable
+    get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
+    get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
+    if(_SAN_CFLAGS)
+        target_compile_options(example_print_version PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            example_print_version
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
 endif()
 
 # Tests
 if(MBELIB_BUILD_TESTS)
-  include(CTest)
-  enable_testing()
-  # Golden data generator tool (not a test): helpful for refreshing hashes
-  add_executable(gen_golden tools/gen_golden.c)
-  target_link_libraries(gen_golden PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(gen_golden PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  add_executable(test_api tests/test_api.c)
-  target_link_libraries(test_api PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_api PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  # Propagate sanitizer flags to test executables
-  get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
-  get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
-  if(_SAN_CFLAGS)
-    target_compile_options(test_api PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_api BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_api COMMAND test_api)
+    include(CTest)
+    enable_testing()
+    # Golden data generator tool (not a test): helpful for refreshing hashes
+    add_executable(gen_golden tools/gen_golden.c)
+    target_link_libraries(gen_golden PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        gen_golden
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    add_executable(test_api tests/test_api.c)
+    target_link_libraries(test_api PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(test_api PRIVATE "${PROJECT_SOURCE_DIR}/include")
+    # Propagate sanitizer flags to test executables
+    get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
+    get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
+    if(_SAN_CFLAGS)
+        target_compile_options(test_api PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(test_api BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_test(NAME test_api COMMAND test_api)
 
-  add_executable(test_ecc tests/test_ecc.c)
-  target_link_libraries(test_ecc PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_ecc PRIVATE "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/src/internal")
-  if(_SAN_CFLAGS)
-    target_compile_options(test_ecc PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_ecc BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_ecc COMMAND test_ecc)
+    add_executable(test_ecc tests/test_ecc.c)
+    target_link_libraries(test_ecc PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        test_ecc
+        PRIVATE
+            "${PROJECT_SOURCE_DIR}/include"
+            "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(test_ecc PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(test_ecc BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_test(NAME test_ecc COMMAND test_ecc)
 
-  add_executable(test_noise_determinism tests/test_noise_determinism.c)
-  target_link_libraries(test_noise_determinism PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_noise_determinism PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  if(_SAN_CFLAGS)
-    target_compile_options(test_noise_determinism PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_noise_determinism BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_noise_determinism COMMAND test_noise_determinism)
+    add_executable(test_noise_determinism tests/test_noise_determinism.c)
+    target_link_libraries(
+        test_noise_determinism
+        PRIVATE ${MBELIB_EXEC_LINK_TGT}
+    )
+    target_include_directories(
+        test_noise_determinism
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(test_noise_determinism PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            test_noise_determinism
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
+    add_test(NAME test_noise_determinism COMMAND test_noise_determinism)
 
-  add_executable(test_params tests/test_params.c)
-  target_link_libraries(test_params PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_params PRIVATE "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/src/internal")
-  if(_SAN_CFLAGS)
-    target_compile_options(test_params PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_params BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_params COMMAND test_params)
+    add_executable(test_params tests/test_params.c)
+    target_link_libraries(test_params PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        test_params
+        PRIVATE
+            "${PROJECT_SOURCE_DIR}/include"
+            "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(test_params PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(test_params BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_test(NAME test_params COMMAND test_params)
 
-  add_executable(test_floattoshort_parity tests/test_floattoshort_parity.c)
-  target_link_libraries(test_floattoshort_parity PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_floattoshort_parity PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  if(_SAN_CFLAGS)
-    target_compile_options(test_floattoshort_parity PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_floattoshort_parity BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_floattoshort_parity COMMAND test_floattoshort_parity)
+    add_executable(test_floattoshort_parity tests/test_floattoshort_parity.c)
+    target_link_libraries(
+        test_floattoshort_parity
+        PRIVATE ${MBELIB_EXEC_LINK_TGT}
+    )
+    target_include_directories(
+        test_floattoshort_parity
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(test_floattoshort_parity PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            test_floattoshort_parity
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
+    add_test(NAME test_floattoshort_parity COMMAND test_floattoshort_parity)
 
-  add_executable(test_golden_pcm tests/test_golden_pcm.c)
-  target_link_libraries(test_golden_pcm PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(test_golden_pcm PRIVATE "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/src/internal")
-  # In Debug, enforce strict float and int16 golden hashes on x86 (single- and multi-config)
-  target_compile_definitions(test_golden_pcm PRIVATE $<$<CONFIG:Debug>:MBELIB_TEST_STRICT_FLOAT=1;MBELIB_TEST_STRICT_INT16=1>)
-  if(MBELIB_ENABLE_SIMD)
-    target_compile_definitions(test_golden_pcm PRIVATE MBELIB_TEST_BUILD_SIMD=1)
-  endif()
-  if(_SAN_CFLAGS)
-    target_compile_options(test_golden_pcm PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_golden_pcm BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_golden_pcm COMMAND test_golden_pcm)
+    add_executable(test_golden_pcm tests/test_golden_pcm.c)
+    target_link_libraries(test_golden_pcm PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        test_golden_pcm
+        PRIVATE
+            "${PROJECT_SOURCE_DIR}/include"
+            "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    # In Debug, enforce strict float and int16 golden hashes on x86 (single- and multi-config)
+    target_compile_definitions(
+        test_golden_pcm
+        PRIVATE
+            $<$<CONFIG:Debug>:MBELIB_TEST_STRICT_FLOAT=1;MBELIB_TEST_STRICT_INT16=1>
+    )
+    if(MBELIB_ENABLE_SIMD)
+        target_compile_definitions(
+            test_golden_pcm
+            PRIVATE MBELIB_TEST_BUILD_SIMD=1
+        )
+    endif()
+    if(_SAN_CFLAGS)
+        target_compile_options(test_golden_pcm PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(test_golden_pcm BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_test(NAME test_golden_pcm COMMAND test_golden_pcm)
 
-  add_executable(test_simd_arch_detection_x64 tests/test_simd_arch_detection.c)
-  target_include_directories(test_simd_arch_detection_x64 PRIVATE "${PROJECT_SOURCE_DIR}/src/internal")
-  target_compile_definitions(test_simd_arch_detection_x64 PRIVATE MBE_TEST_SCENARIO_X64=1)
-  if(_SAN_CFLAGS)
-    target_compile_options(test_simd_arch_detection_x64 PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_simd_arch_detection_x64 BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_simd_arch_detection_x64 COMMAND test_simd_arch_detection_x64)
+    add_executable(
+        test_simd_arch_detection_x64
+        tests/test_simd_arch_detection.c
+    )
+    target_include_directories(
+        test_simd_arch_detection_x64
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    target_compile_definitions(
+        test_simd_arch_detection_x64
+        PRIVATE MBE_TEST_SCENARIO_X64=1
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(
+            test_simd_arch_detection_x64
+            PRIVATE ${_SAN_CFLAGS}
+        )
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            test_simd_arch_detection_x64
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
+    add_test(
+        NAME test_simd_arch_detection_x64
+        COMMAND test_simd_arch_detection_x64
+    )
 
-  add_executable(test_simd_arch_detection_arm64ec tests/test_simd_arch_detection.c)
-  target_include_directories(test_simd_arch_detection_arm64ec PRIVATE "${PROJECT_SOURCE_DIR}/src/internal")
-  target_compile_definitions(test_simd_arch_detection_arm64ec PRIVATE MBE_TEST_SCENARIO_ARM64EC=1)
-  if(_SAN_CFLAGS)
-    target_compile_options(test_simd_arch_detection_arm64ec PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_simd_arch_detection_arm64ec BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_simd_arch_detection_arm64ec COMMAND test_simd_arch_detection_arm64ec)
+    add_executable(
+        test_simd_arch_detection_arm64ec
+        tests/test_simd_arch_detection.c
+    )
+    target_include_directories(
+        test_simd_arch_detection_arm64ec
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    target_compile_definitions(
+        test_simd_arch_detection_arm64ec
+        PRIVATE MBE_TEST_SCENARIO_ARM64EC=1
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(
+            test_simd_arch_detection_arm64ec
+            PRIVATE ${_SAN_CFLAGS}
+        )
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            test_simd_arch_detection_arm64ec
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
+    add_test(
+        NAME test_simd_arch_detection_arm64ec
+        COMMAND test_simd_arch_detection_arm64ec
+    )
 
-  add_executable(test_simd_arch_detection_x86_32_msvc_sse2 tests/test_simd_arch_detection.c)
-  target_include_directories(test_simd_arch_detection_x86_32_msvc_sse2 PRIVATE "${PROJECT_SOURCE_DIR}/src/internal")
-  target_compile_definitions(test_simd_arch_detection_x86_32_msvc_sse2
-    PRIVATE
-      MBE_TEST_SCENARIO_X86_32_MSVC_SSE2=1
-      _M_IX86_FP=2)
-  if(_SAN_CFLAGS)
-    target_compile_options(test_simd_arch_detection_x86_32_msvc_sse2 PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(test_simd_arch_detection_x86_32_msvc_sse2 BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_test(NAME test_simd_arch_detection_x86_32_msvc_sse2 COMMAND test_simd_arch_detection_x86_32_msvc_sse2)
+    add_executable(
+        test_simd_arch_detection_x86_32_msvc_sse2
+        tests/test_simd_arch_detection.c
+    )
+    target_include_directories(
+        test_simd_arch_detection_x86_32_msvc_sse2
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/internal"
+    )
+    target_compile_definitions(
+        test_simd_arch_detection_x86_32_msvc_sse2
+        PRIVATE MBE_TEST_SCENARIO_X86_32_MSVC_SSE2=1 _M_IX86_FP=2
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(
+            test_simd_arch_detection_x86_32_msvc_sse2
+            PRIVATE ${_SAN_CFLAGS}
+        )
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(
+            test_simd_arch_detection_x86_32_msvc_sse2
+            BEFORE
+            PRIVATE ${_SAN_LDFLAGS}
+        )
+    endif()
+    add_test(
+        NAME test_simd_arch_detection_x86_32_msvc_sse2
+        COMMAND test_simd_arch_detection_x86_32_msvc_sse2
+    )
 endif()
 
 # Benchmarks (opt-in)
 if(MBELIB_BUILD_BENCHMARKS)
-  add_executable(bench_synth bench/bench_synth.c)
-  target_link_libraries(bench_synth PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(bench_synth PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  # Propagate sanitizer flags if present
-  get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
-  get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
-  if(_SAN_CFLAGS)
-    target_compile_options(bench_synth PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(bench_synth BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_executable(bench_unvoiced bench/bench_unvoiced.c)
-  target_link_libraries(bench_unvoiced PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(bench_unvoiced PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  if(_SAN_CFLAGS)
-    target_compile_options(bench_unvoiced PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(bench_unvoiced BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
-  add_executable(bench_convert bench/bench_convert.c)
-  target_link_libraries(bench_convert PRIVATE ${MBELIB_EXEC_LINK_TGT})
-  target_include_directories(bench_convert PRIVATE "${PROJECT_SOURCE_DIR}/include")
-  if(_SAN_CFLAGS)
-    target_compile_options(bench_convert PRIVATE ${_SAN_CFLAGS})
-  endif()
-  if(_SAN_LDFLAGS)
-    target_link_options(bench_convert BEFORE PRIVATE ${_SAN_LDFLAGS})
-  endif()
+    add_executable(bench_synth bench/bench_synth.c)
+    target_link_libraries(bench_synth PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        bench_synth
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    # Propagate sanitizer flags if present
+    get_directory_property(_SAN_CFLAGS MBELIB_SANITIZER_CFLAGS)
+    get_directory_property(_SAN_LDFLAGS MBELIB_SANITIZER_LDFLAGS)
+    if(_SAN_CFLAGS)
+        target_compile_options(bench_synth PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(bench_synth BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_executable(bench_unvoiced bench/bench_unvoiced.c)
+    target_link_libraries(bench_unvoiced PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        bench_unvoiced
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(bench_unvoiced PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(bench_unvoiced BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_executable(bench_convert bench/bench_convert.c)
+    target_link_libraries(bench_convert PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        bench_convert
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(bench_convert PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(bench_convert BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
 endif()
 
 # Uninstall target
 configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-  IMMEDIATE @ONLY)
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE
+    @ONLY
+)
 
-add_custom_target(uninstall
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+add_custom_target(
+    uninstall
+    COMMAND
+        ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled on the default branch and the latest tagged release line.
+
+## Reporting A Vulnerability
+
+Please do not report suspected vulnerabilities through public GitHub issues.
+
+Use GitHub private vulnerability reporting or a draft GitHub Security Advisory for this repository. Include:
+
+- affected commit, tag, or release
+- platform and build configuration
+- reproduction steps or proof of concept
+- expected impact
+- whether the issue may expose credentials, keys, captures, or user data
+
+The maintainer will acknowledge valid reports through the private GitHub security channel and coordinate disclosure there.
+
+## Handling Sensitive Artifacts
+
+Do not attach private captures, credentials, radio keys, or machine-specific configuration to public issues or pull requests. Redact or synthesize test data before sharing it publicly.

--- a/cmake/mbe-neoConfig.cmake.in
+++ b/cmake/mbe-neoConfig.cmake.in
@@ -7,10 +7,10 @@ include("${CMAKE_CURRENT_LIST_DIR}/mbe-neoTargets.cmake")
 
 # Provide underscore-named aliases for convenience/compatibility
 if(NOT TARGET mbe_neo::mbe_shared AND TARGET mbe_neo::mbe-shared)
-  add_library(mbe_neo::mbe_shared ALIAS mbe_neo::mbe-shared)
+    add_library(mbe_neo::mbe_shared ALIAS mbe_neo::mbe-shared)
 endif()
 if(NOT TARGET mbe_neo::mbe_static AND TARGET mbe_neo::mbe-static)
-  add_library(mbe_neo::mbe_static ALIAS mbe_neo::mbe-static)
+    add_library(mbe_neo::mbe_static ALIAS mbe_neo::mbe-static)
 endif()
 
 check_required_components(mbe-neo)

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,23 +1,29 @@
-if (NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-    message(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+    message(
+        FATAL_ERROR
+        "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\""
+    )
 endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
 
 file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 list(FILTER files EXCLUDE REGEX "^$")
 list(REVERSE files)
-foreach (file ${files})
+foreach(file ${files})
     message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
-    if (EXISTS "$ENV{DESTDIR}${file}")
+    if(EXISTS "$ENV{DESTDIR}${file}")
         execute_process(
             COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
             OUTPUT_VARIABLE rm_out
             RESULT_VARIABLE rm_retval
         )
         if(NOT ${rm_retval} EQUAL 0)
-            message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
-        endif (NOT ${rm_retval} EQUAL 0)
-    else (EXISTS "$ENV{DESTDIR}${file}")
+            message(
+                FATAL_ERROR
+                "Problem when removing \"$ENV{DESTDIR}${file}\""
+            )
+        endif(NOT ${rm_retval} EQUAL 0)
+    else(EXISTS "$ENV{DESTDIR}${file}")
         message(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
-    endif (EXISTS "$ENV{DESTDIR}${file}")
+    endif(EXISTS "$ENV{DESTDIR}${file}")
 endforeach(file)

--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -1,0 +1,43 @@
+# Code Quality Guardrails
+
+mbelib-neo relies on layered checks because no single compiler, analyzer, or review pass catches every bad change. These guardrails apply to hand-written, copied, generated, and bulk-edited code equally.
+
+## Review Expectations
+
+- A human owns every submitted change and is responsible for understanding the behavior, failure modes, and module boundaries it touches.
+- Broad or risky changes need a second reviewer. Treat codec, DSP, API/ABI, workflow, dependency, and release changes as risky by default.
+- Copied, generated, or bulk-written code must be adapted to local conventions before review, not accepted as a black box.
+- Static-analysis suppressions must explain why the warning is a false positive or why the local exception is acceptable. Keep suppressions close to the narrowest affected code.
+- Do not add unrelated refactors to quality or security fixes. Smaller diffs make analyzer output and review results more reliable.
+
+## High-Risk Change Checklist
+
+Use this checklist when a change touches decoder logic, external input, allocation, dependencies, workflows, or packaging:
+
+- Add or update focused tests under the matching `tests/` area.
+- For new public APIs, verify headers live under `include/mbelib-neo/` and are included as `<mbelib-neo/...>`.
+- For new dependencies, document the dependency in CMake, README/install notes, and license notices as applicable.
+- For workflow changes, keep `GITHUB_TOKEN` permissions least-privilege and avoid interpolating untrusted GitHub context directly into shell scripts.
+- For release changes, verify artifact and checksum steps still run on tag builds.
+- For dependency or workflow changes, also check the supply-chain policy in `docs/supply-chain-guardrails.md`.
+
+## Required Local Checks
+
+Run the smallest useful set before opening a PR, then broaden it when the change is risky.
+
+- Normal C changes: `cmake --build --preset dev-debug -j` and `ctest --preset dev-debug --output-on-failure`.
+- Normal pre-push check: `tools/preflight_ci.sh`.
+- Broad or high-risk changes: `tools/quality_preflight.sh`.
+- Sanitizer-sensitive code: `ctest --preset asan-ubsan-debug --output-on-failure` after configuring/building the matching preset.
+- CMake changes: `tools/cmake_format_check.sh`.
+- Workflow changes: `tools/workflow_lint.sh` and `tools/zizmor.sh`.
+- Dependency input changes: `tools/osv_scan.sh`.
+
+## Project-Specific Guardrails
+
+The repository intentionally blocks or flags patterns that are easy to reintroduce during large edits:
+
+- Do not execute shells or spawn processes from project-owned C without explicit design review.
+- Do not include bundled third-party headers directly outside approved integration points.
+- Keep workflow scripts defensive: pass untrusted context through environment variables or action inputs, not direct expression interpolation in `run:` blocks.
+- Keep analyzer and linter output actionable. Prefer fixing root causes over widening suppressions.

--- a/docs/supply-chain-guardrails.md
+++ b/docs/supply-chain-guardrails.md
@@ -1,0 +1,24 @@
+# Supply-Chain Guardrails
+
+mbelib-neo keeps CI dependencies explicit so analyzer results and release artifacts are reproducible.
+
+## GitHub Actions
+
+- Workflow security is checked with `tools/workflow_lint.sh`, Semgrep workflow rules, CodeQL Actions analysis, Gitleaks, OpenSSF Scorecard, and `tools/zizmor.sh`.
+- The current zizmor policy in `.github/zizmor.yml` requires every external `uses:` action to be pinned to a full commit SHA.
+- For new or refreshed third-party actions in release, packaging, signing, attestation, or upload workflows, resolve the upstream tag to the immutable commit and pin that SHA.
+- Workflow changes that add secrets, write permissions, artifact publication, release upload, or external actions need human review.
+
+## Vendored Code
+
+Vendored third-party sources live under `src/external/` and are excluded from project-owned analyzer findings where the tool supports path filtering.
+
+- Keep bundled dependency updates small and traceable to an upstream release or commit.
+- Preserve upstream license files and attribution.
+- Re-run focused codec tests plus `tools/osv_scan.sh` after dependency updates.
+
+## Vulnerability Scanning
+
+- `tools/osv_scan.sh` runs OSV-Scanner source scanning for lockfiles, manifests, and vendored C/C++ dependency fingerprints.
+- PR CI runs OSV when dependency inputs change; scheduled guardrails run a full repository scan.
+- If OSV reports a vulnerability that is not exploitable in mbelib-neo, add the narrowest possible `osv-scanner.toml` ignore with a reason and expiry date.

--- a/semgrep/mbelib-neo.yml
+++ b/semgrep/mbelib-neo.yml
@@ -1,0 +1,62 @@
+rules:
+  - id: mbelib-neo.no-shell-exec
+    languages: [c]
+    severity: ERROR
+    message: Do not invoke shells or spawn processes from project-owned C code without explicit design review.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /tests/**
+        - /examples/**
+        - /bench/**
+      exclude:
+        - /src/external/**
+    pattern-either:
+      - pattern: system(...)
+      - pattern: popen(...)
+      - pattern: execl(...)
+      - pattern: execle(...)
+      - pattern: execlp(...)
+      - pattern: execv(...)
+      - pattern: execve(...)
+      - pattern: execvp(...)
+      - pattern: posix_spawn(...)
+      - pattern: posix_spawnp(...)
+
+  - id: mbelib-neo.no-direct-third-party-include
+    languages: [c]
+    severity: ERROR
+    message: Use a project-owned integration point instead of directly including bundled third-party headers.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /tests/**
+        - /examples/**
+        - /bench/**
+      exclude:
+        - /src/external/**
+        - /src/core/mbe_unvoiced_fft.c
+    pattern-either:
+      - pattern: '#include "src/external/..."'
+      - pattern: '#include <src/external/...>'
+      - pattern: '#include "pffft.h"'
+      - pattern: '#include <pffft.h>'
+      - pattern: '#include "fftpack.h"'
+      - pattern: '#include <fftpack.h>'
+
+  - id: mbelib-neo.github-actions.no-untrusted-context-in-run
+    languages: [yaml]
+    severity: ERROR
+    message: Pass untrusted GitHub context through env or action inputs instead of interpolating it directly into a run block.
+    paths:
+      include:
+        - /.github/workflows/*.yml
+        - /.github/workflows/*.yaml
+    patterns:
+      - pattern: |
+          run: $SCRIPT
+      - metavariable-regex:
+          metavariable: $SCRIPT
+          regex: '(?s).*\$\{\{\s*github\.(?:head_ref|ref_name|event\.(?:issue\.(?:title|body)|comment\.body|pull_request\.(?:title|body)|pull_request\.head\.(?:ref|label)|pull_request\.head\.repo\.full_name)).*'

--- a/tools/bench_compare.sh
+++ b/tools/bench_compare.sh
@@ -13,19 +13,19 @@ echo "== Configure scalar benchmark build =="
 cmake --preset dev-release \
   -B "$scalar_build" \
   -DMBELIB_ENABLE_SIMD=OFF \
-  -DMBELIB_BUILD_BENCHMARKS=ON >/dev/null
+  -DMBELIB_BUILD_BENCHMARKS=ON > /dev/null
 
 echo "== Build scalar benchmark =="
-cmake --build "$scalar_build" -j --target bench_synth >/dev/null || cmake --build "$scalar_build" -j >/dev/null
+cmake --build "$scalar_build" -j --target bench_synth > /dev/null || cmake --build "$scalar_build" -j > /dev/null
 
 echo "== Configure SIMD benchmark build =="
 cmake --preset dev-release \
   -B "$simd_build" \
   -DMBELIB_ENABLE_SIMD=ON \
-  -DMBELIB_BUILD_BENCHMARKS=ON >/dev/null
+  -DMBELIB_BUILD_BENCHMARKS=ON > /dev/null
 
 echo "== Build SIMD benchmark =="
-cmake --build "$simd_build" -j --target bench_synth >/dev/null || cmake --build "$simd_build" -j >/dev/null
+cmake --build "$simd_build" -j --target bench_synth > /dev/null || cmake --build "$simd_build" -j > /dev/null
 
 echo
 echo "== Running scalar benchmark =="

--- a/tools/ci_arch_toolchain.sh
+++ b/tools/ci_arch_toolchain.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/ci_arch_toolchain.sh <command> [args...]
 
 Run a command in an Arch Linux container with the rolling C/C++ quality
@@ -21,12 +21,12 @@ if [[ $# -eq 0 ]]; then
   exit 2
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
+if ! command -v docker > /dev/null 2>&1; then
   echo "docker not found; required for Arch toolchain CI wrapper." >&2
   exit 1
 fi
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 IMAGE="${CI_ARCH_IMAGE:-archlinux:base-devel}"
 ARCH_TOOLCHAIN_PREFIX="${CI_ARCH_TOOLCHAIN_PREFIX:-/workspace/.deps-arch-toolchain}"
 
@@ -51,7 +51,7 @@ fi
 
 NEED_IWYU="${CI_ARCH_ENABLE_IWYU:-0}"
 case " $* " in
-  *"tools/iwyu.sh"*|*"include-what-you-use"*) NEED_IWYU=1 ;;
+  *"tools/iwyu.sh"* | *"include-what-you-use"*) NEED_IWYU=1 ;;
 esac
 
 ENV_ARGS=(

--- a/tools/ci_changed_files.sh
+++ b/tools/ci_changed_files.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compute the changed-file target sets used by pull-request CI.
+# Changed source files are analyzed directly, and changed headers expand to
+# representative C translation units.
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/ci_changed_files.sh --base <ref-or-sha> [--head <ref-or-sha>] [--out-dir <dir>]
+
+Writes newline-delimited target files for CI jobs:
+  changed_paths.txt
+  format_files.txt
+  analysis_tus.txt
+  cppcheck_sources.txt
+  semgrep_targets.txt
+  cmake_format_files.txt
+  workflow_security_targets.txt
+  dependency_scan_targets.txt
+
+Options:
+  --base REF      Base ref/SHA for the PR diff.
+  --head REF      Head ref/SHA for the PR diff (default: HEAD).
+  --out-dir DIR   Output directory (default: .ci/changed-files).
+  --no-header-expansion
+                  Do not expand changed headers to including translation units.
+  -h, --help      Show this help.
+USAGE
+}
+
+BASE_REF=""
+HEAD_REF="HEAD"
+OUT_DIR=".ci/changed-files"
+MAX_TUS_PER_HEADER=10
+EXPAND_HEADERS=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --base" >&2
+        exit 2
+      fi
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --head)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --head" >&2
+        exit 2
+      fi
+      HEAD_REF="$2"
+      shift 2
+      ;;
+    --out-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --out-dir" >&2
+        exit 2
+      fi
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --no-header-expansion)
+      EXPAND_HEADERS=0
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$BASE_REF" ]]; then
+  echo "Missing required --base ref/SHA" >&2
+  usage >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify "$BASE_REF^{commit}" > /dev/null 2>&1; then
+  echo "Unable to resolve base ref/SHA: $BASE_REF" >&2
+  exit 2
+fi
+if ! git rev-parse --verify "$HEAD_REF^{commit}" > /dev/null 2>&1; then
+  echo "Unable to resolve head ref/SHA: $HEAD_REF" >&2
+  exit 2
+fi
+
+write_list() {
+  local path="$1"
+  shift
+  mkdir -p "$(dirname "$path")"
+  : > "$path"
+  if [[ $# -gt 0 ]]; then
+    printf '%s\n' "$@" > "$path"
+  fi
+}
+
+sort_unique_array() {
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+  printf '%s\n' "$@" | sort -u
+}
+
+escape_rg() {
+  printf '%s' "$1" | sed -e 's/[][(){}.^$*+?|\\]/\\&/g'
+}
+
+collect_header_includers() {
+  local pattern="$1"
+  rg -l --glob '!src/external/**' \
+    -g'*.c' \
+    "$pattern" src tests examples bench 2> /dev/null |
+    sort |
+    head -n "$MAX_TUS_PER_HEADER" || true
+}
+
+mkdir -p "$OUT_DIR"
+
+mapfile -t changed_paths < <(
+  git diff --name-only --diff-filter=ACMR "${BASE_REF}...${HEAD_REF}" ||
+    git diff --name-only --diff-filter=ACMR "$BASE_REF" "$HEAD_REF"
+)
+
+if [[ ${#changed_paths[@]} -eq 0 ]]; then
+  write_list "$OUT_DIR/changed_paths.txt"
+  write_list "$OUT_DIR/format_files.txt"
+  write_list "$OUT_DIR/analysis_tus.txt"
+  write_list "$OUT_DIR/cppcheck_sources.txt"
+  write_list "$OUT_DIR/semgrep_targets.txt"
+  write_list "$OUT_DIR/cmake_format_files.txt"
+  write_list "$OUT_DIR/workflow_security_targets.txt"
+  write_list "$OUT_DIR/dependency_scan_targets.txt"
+else
+  mapfile -t changed_paths < <(sort_unique_array "${changed_paths[@]}")
+fi
+
+changed_sources=()
+changed_headers=()
+format_files=()
+semgrep_targets=()
+cmake_format_files=()
+workflow_security_targets=()
+dependency_scan_targets=()
+
+for p in "${changed_paths[@]}"; do
+  case "$p" in
+    build/* | src/external/*) continue ;;
+  esac
+
+  if [[ ! -e "$p" && ! -L "$p" ]]; then
+    continue
+  fi
+
+  case "$p" in
+    src/* | include/* | examples/* | bench/* | tests/* | tools/* | .github/workflows/*.yml | .github/workflows/*.yaml)
+      semgrep_targets+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    CMakeLists.txt | */CMakeLists.txt | CMakeLists.txt.in | */CMakeLists.txt.in | *.cmake | *.cmake.in)
+      cmake_format_files+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    .github/workflows/*.yml | .github/workflows/*.yaml | .github/dependabot.yml | .github/zizmor.yml)
+      workflow_security_targets+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    .github/dependabot.yml | tools/osv_scan.sh | src/external/*)
+      dependency_scan_targets+=("$p")
+      ;;
+  esac
+
+  case "$p" in
+    *.c | *.cc | *.cpp | *.cxx)
+      changed_sources+=("$p")
+      format_files+=("$p")
+      ;;
+    *.h | *.hh | *.hpp | *.hxx)
+      changed_headers+=("$p")
+      format_files+=("$p")
+      ;;
+  esac
+done
+
+analysis_tus=("${changed_sources[@]}")
+if [[ $EXPAND_HEADERS -eq 1 && ${#changed_headers[@]} -gt 0 ]]; then
+  if command -v rg > /dev/null 2>&1; then
+    for hdr in "${changed_headers[@]}"; do
+      include_key=""
+      pattern=""
+      if [[ "$hdr" == include/* ]]; then
+        include_key="${hdr#include/}"
+        include_key=$(escape_rg "$include_key")
+        pattern="^[[:space:]]*#[[:space:]]*include[[:space:]]*[<\\\"]${include_key}[>\\\"]"
+      else
+        include_key=$(basename "$hdr")
+        include_key=$(escape_rg "$include_key")
+        pattern="^[[:space:]]*#[[:space:]]*include[[:space:]]*[<\\\"][^>\\\"]*${include_key}[>\\\"]"
+      fi
+
+      mapfile -t matches < <(collect_header_includers "$pattern")
+      analysis_tus+=("${matches[@]}")
+    done
+  else
+    echo "ci-changed-files: rg not found; header include expansion skipped." >&2
+  fi
+fi
+
+cppcheck_sources=()
+for p in "${analysis_tus[@]}"; do
+  case "$p" in
+    src/*) cppcheck_sources+=("$p") ;;
+  esac
+done
+
+if [[ ${#format_files[@]} -gt 0 ]]; then
+  mapfile -t format_files < <(sort_unique_array "${format_files[@]}")
+fi
+if [[ ${#semgrep_targets[@]} -gt 0 ]]; then
+  mapfile -t semgrep_targets < <(sort_unique_array "${semgrep_targets[@]}")
+fi
+if [[ ${#analysis_tus[@]} -gt 0 ]]; then
+  mapfile -t analysis_tus < <(sort_unique_array "${analysis_tus[@]}")
+fi
+if [[ ${#cppcheck_sources[@]} -gt 0 ]]; then
+  mapfile -t cppcheck_sources < <(sort_unique_array "${cppcheck_sources[@]}")
+fi
+if [[ ${#cmake_format_files[@]} -gt 0 ]]; then
+  mapfile -t cmake_format_files < <(sort_unique_array "${cmake_format_files[@]}")
+fi
+if [[ ${#workflow_security_targets[@]} -gt 0 ]]; then
+  mapfile -t workflow_security_targets < <(sort_unique_array "${workflow_security_targets[@]}")
+fi
+if [[ ${#dependency_scan_targets[@]} -gt 0 ]]; then
+  mapfile -t dependency_scan_targets < <(sort_unique_array "${dependency_scan_targets[@]}")
+fi
+
+write_list "$OUT_DIR/changed_paths.txt" "${changed_paths[@]}"
+write_list "$OUT_DIR/format_files.txt" "${format_files[@]}"
+write_list "$OUT_DIR/analysis_tus.txt" "${analysis_tus[@]}"
+write_list "$OUT_DIR/cppcheck_sources.txt" "${cppcheck_sources[@]}"
+write_list "$OUT_DIR/semgrep_targets.txt" "${semgrep_targets[@]}"
+write_list "$OUT_DIR/cmake_format_files.txt" "${cmake_format_files[@]}"
+write_list "$OUT_DIR/workflow_security_targets.txt" "${workflow_security_targets[@]}"
+write_list "$OUT_DIR/dependency_scan_targets.txt" "${dependency_scan_targets[@]}"
+
+echo "ci-changed-files: base=${BASE_REF} head=${HEAD_REF}"
+echo "ci-changed-files: changed=${#changed_paths[@]} format=${#format_files[@]}" \
+  "tus=${#analysis_tus[@]} cppcheck=${#cppcheck_sources[@]} semgrep=${#semgrep_targets[@]}" \
+  "cmake=${#cmake_format_files[@]} workflows=${#workflow_security_targets[@]}" \
+  "deps=${#dependency_scan_targets[@]}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "out_dir=$OUT_DIR"
+    echo "changed_paths=${#changed_paths[@]}"
+    echo "format_files=${#format_files[@]}"
+    echo "analysis_tus=${#analysis_tus[@]}"
+    echo "cppcheck_sources=${#cppcheck_sources[@]}"
+    echo "semgrep_targets=${#semgrep_targets[@]}"
+    echo "cmake_format_files=${#cmake_format_files[@]}"
+    echo "workflow_security_targets=${#workflow_security_targets[@]}"
+    echo "dependency_scan_targets=${#dependency_scan_targets[@]}"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/tools/clang_tidy.sh
+++ b/tools/clang_tidy.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 # - Analyzes translation units in the compilation database using the repo's .clang-tidy
 # - Fails if any diagnostics are emitted as errors (WarningsAsErrors), or if clang-tidy can't process a file
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/clang_tidy.sh [--strict] [--all-commands] [--] [files...]
 
 Options:
@@ -32,24 +32,40 @@ ALL_COMMANDS=0
 REQUESTED_FILES=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --strict) STRICT=1; shift ;;
-    --all-commands) ALL_COMMANDS=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    --) shift; REQUESTED_FILES+=("$@"); break ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --all-commands)
+      ALL_COMMANDS=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      REQUESTED_FILES+=("$@")
+      break
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       usage >&2
       exit 2
       ;;
-    *) REQUESTED_FILES+=("$1"); shift ;;
+    *)
+      REQUESTED_FILES+=("$1")
+      shift
+      ;;
   esac
 done
 
-if ! command -v clang-tidy >/dev/null 2>&1; then
+if ! command -v clang-tidy > /dev/null 2>&1; then
   echo "clang-tidy not found. Please install it (e.g., apt-get install clang-tidy)." >&2
   exit 1
 fi
-if ! command -v rg >/dev/null 2>&1; then
+if ! command -v rg > /dev/null 2>&1; then
   echo "ripgrep (rg) not found. Please install it (e.g., apt-get install ripgrep)." >&2
   exit 1
 fi
@@ -62,7 +78,7 @@ if [ ! -f "$PDB_FILE" ]; then
     PDB_DIR="."
   else
     echo "Configuring CMake preset 'dev-debug' to generate compile_commands.json..."
-    cmake --preset dev-debug >/dev/null
+    cmake --preset dev-debug > /dev/null
   fi
 fi
 
@@ -71,14 +87,15 @@ fi
 PDB_FILE="$PDB_DIR/compile_commands.json"
 TIDY_PDB_DIR="$PDB_DIR"
 TIDY_PDB_TEMP_DIR=""
-if command -v python3 >/dev/null 2>&1; then
+if command -v python3 > /dev/null 2>&1; then
   if [[ $ALL_COMMANDS -eq 0 ]]; then
-    TIDY_PDB_TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t mbelib-neo-clang-tidy)
+    TIDY_PDB_TEMP_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t mbelib-neo-clang-tidy)
     trap 'rm -rf "$TIDY_PDB_TEMP_DIR" 2>/dev/null || true' EXIT
     TIDY_PDB_DIR="$TIDY_PDB_TEMP_DIR"
   fi
 
-  mapfile -t FILES < <(python3 - "$PDB_FILE" "$ROOT_DIR" "$TIDY_PDB_DIR" "$ALL_COMMANDS" "${REQUESTED_FILES[@]}" <<'PY'
+  mapfile -t FILES < <(
+    python3 - "$PDB_FILE" "$ROOT_DIR" "$TIDY_PDB_DIR" "$ALL_COMMANDS" "${REQUESTED_FILES[@]}" << 'PY'
 import json
 import pathlib
 import shlex
@@ -244,10 +261,10 @@ else
     for f in "${REQUESTED_FILES[@]}"; do
       f="${f#./}"
       case "$f" in
-        build/*|src/external/*) continue ;;
+        build/* | src/external/*) continue ;;
       esac
       case "$f" in
-        *.c|*.cc|*.cpp|*.cxx) FILES+=("$f") ;;
+        *.c | *.cc | *.cpp | *.cxx) FILES+=("$f") ;;
       esac
     done
   else
@@ -284,22 +301,22 @@ if [[ $STRICT -eq 1 ]]; then
 fi
 
 if [[ -f "$CONFIG_FILE" ]]; then
-  CFG_PATH=$(readlink -f "$CONFIG_FILE" 2>/dev/null || echo "$CONFIG_FILE")
+  CFG_PATH=$(readlink -f "$CONFIG_FILE" 2> /dev/null || echo "$CONFIG_FILE")
   echo "Using config file: $CFG_PATH"
 else
   echo "Config file not found: $CONFIG_FILE (clang-tidy will use built-in defaults)"
 fi
 
-clang-tidy -p "$TIDY_PDB_DIR" --config-file "$CONFIG_FILE" "${FILES[@]}" 2>&1 | tee "$LOG_FILE" >/dev/null || true
+clang-tidy -p "$TIDY_PDB_DIR" --config-file "$CONFIG_FILE" "${FILES[@]}" 2>&1 | tee "$LOG_FILE" > /dev/null || true
 
 # Fail on error diagnostics (WarningsAsErrors) and on clang-tidy processing failures.
-if rg -n "error:" "$LOG_FILE" >/dev/null; then
+if rg -n "error:" "$LOG_FILE" > /dev/null; then
   echo "clang-tidy emitted diagnostics treated as errors. See $LOG_FILE for details." >&2
   echo "Summary (errors by check):" >&2
   rg -n "error:.*\\[[^]]+\\]$" "$LOG_FILE" | sed -E 's/.*\[([^]]+)\]$/\1/' | awk -F',' '{print $1}' | sort | uniq -c | sort -nr >&2
   exit 1
 fi
-if rg -n "^Error while processing " "$LOG_FILE" >/dev/null; then
+if rg -n "^Error while processing " "$LOG_FILE" > /dev/null; then
   echo "clang-tidy failed to process one or more files. See $LOG_FILE for details." >&2
   rg -n "^Error while processing " "$LOG_FILE" >&2 || true
   exit 1

--- a/tools/cmake_format_check.sh
+++ b/tools/cmake_format_check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/cmake_format_check.sh [--fix] [--] [files...]
+
+Checks tracked CMake files with gersemi. With --fix, rewrites files in place.
+When no files are supplied, all tracked CMake files are checked.
+USAGE
+}
+
+FIX=0
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)
+      FIX=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      FILES+=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! command -v gersemi > /dev/null 2>&1; then
+  echo "gersemi not found. Install with: python -m pip install gersemi." >&2
+  exit 1
+fi
+
+is_cmake_file() {
+  case "$1" in
+    CMakeLists.txt | */CMakeLists.txt | CMakeLists.txt.in | */CMakeLists.txt.in | *.cmake | *.cmake.in)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  mapfile -t FILES < <(
+    {
+      git ls-files
+      git ls-files --others --exclude-standard
+    } | while IFS= read -r f; do
+      if is_cmake_file "$f"; then
+        printf '%s\n' "$f"
+      fi
+    done | sort -u
+  )
+fi
+
+FILTERED=()
+for f in "${FILES[@]}"; do
+  f="${f#./}"
+  case "$f" in
+    build/*) continue ;;
+  esac
+  if [[ -f "$f" ]] && is_cmake_file "$f"; then
+    FILTERED+=("$f")
+  fi
+done
+
+if [[ ${#FILTERED[@]} -eq 0 ]]; then
+  echo "No CMake files to check."
+  exit 0
+fi
+
+LOG_FILE=".cmake-format.local.out"
+set +e
+if [[ $FIX -eq 1 ]]; then
+  {
+    echo "gersemi fix files: ${#FILTERED[@]}"
+    gersemi -i --quiet "${FILTERED[@]}"
+  } 2>&1 | tee "$LOG_FILE"
+else
+  {
+    echo "gersemi check files: ${#FILTERED[@]}"
+    gersemi --check --diff --quiet "${FILTERED[@]}"
+  } 2>&1 | tee "$LOG_FILE"
+fi
+rc=${PIPESTATUS[0]}
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  echo "CMake format check completed. Full output in $LOG_FILE"
+else
+  echo "CMake format check failed. Run tools/cmake_format_check.sh --fix." >&2
+fi
+exit "$rc"

--- a/tools/cppcheck.sh
+++ b/tools/cppcheck.sh
@@ -6,17 +6,17 @@ set -euo pipefail
 # - Complements clang-tidy with different analysis techniques
 # - Fails on error-level issues; warnings are informational
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
-if ! command -v cppcheck >/dev/null 2>&1; then
+if ! command -v cppcheck > /dev/null 2>&1; then
   echo "cppcheck not found. Please install it (e.g., apt-get install cppcheck)." >&2
   exit 1
 fi
 
 # Parse arguments
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/cppcheck.sh [--strict] [--verbose|-v] [--] [files...]
 
 Options:
@@ -43,11 +43,11 @@ while [[ $# -gt 0 ]]; do
       STRICT=1
       shift
       ;;
-    --verbose|-v)
+    --verbose | -v)
       VERBOSE=1
       shift
       ;;
-    --help|-h)
+    --help | -h)
       usage
       exit 0
       ;;
@@ -72,7 +72,7 @@ echo "cppcheck version:"
 cppcheck --version
 
 # Detect number of CPU cores for parallel analysis
-NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+NPROC=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)
 CPPCHECK_BUILD_DIR="${CPPCHECK_BUILD_DIR:-.cppcheck-build}"
 mkdir -p "$CPPCHECK_BUILD_DIR"
 
@@ -146,10 +146,10 @@ if [[ ${#REQUESTED_FILES[@]} -gt 0 ]]; then
   for f in "${REQUESTED_FILES[@]}"; do
     f="${f#./}"
     case "$f" in
-      build/*|src/external/*) continue ;;
+      build/* | src/external/*) continue ;;
     esac
     case "$f" in
-      *.c|*.cc|*.cpp|*.cxx) FILES+=("$f") ;;
+      *.c | *.cc | *.cpp | *.cxx) FILES+=("$f") ;;
     esac
   done
 
@@ -186,9 +186,9 @@ else
   # Print summary by severity
   echo ""
   echo "Summary by severity:" >&2
-  grep -E ': (error|warning|style|performance|portability):' "$LOG_FILE" 2>/dev/null \
-    | sed -E 's/.*: (error|warning|style|performance|portability):.*/\1/' \
-    | sort | uniq -c | sort -rn >&2 || true
+  grep -E ': (error|warning|style|performance|portability):' "$LOG_FILE" 2> /dev/null |
+    sed -E 's/.*: (error|warning|style|performance|portability):.*/\1/' |
+    sort | uniq -c | sort -rn >&2 || true
 
   exit $EXIT_CODE
 fi

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -24,7 +24,7 @@ for f in "${files[@]}"; do
 done
 files=("${filtered[@]}")
 
-if command -v clang-format >/dev/null 2>&1; then
+if command -v clang-format > /dev/null 2>&1; then
   if [ ${#files[@]} -eq 0 ]; then
     echo "No C/C headers found to format."
     exit 0

--- a/tools/gcc_fanalyzer.sh
+++ b/tools/gcc_fanalyzer.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 # - Excludes build/ and src/external/
 # - By default, fails on analyzer diagnostics or compiler errors
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/gcc_fanalyzer.sh [--strict] [--all-commands] [--jobs N] [--] [files...]
 
 Options:
@@ -32,8 +32,14 @@ REQUESTED_FILES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --strict) STRICT=1; shift ;;
-    --all-commands) ALL_COMMANDS=1; shift ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --all-commands)
+      ALL_COMMANDS=1
+      shift
+      ;;
     --jobs)
       if [[ $# -lt 2 ]]; then
         echo "Missing value for --jobs" >&2
@@ -42,26 +48,36 @@ while [[ $# -gt 0 ]]; do
       JOBS="$2"
       shift 2
       ;;
-    -h|--help) usage; exit 0 ;;
-    --) shift; REQUESTED_FILES+=("$@"); break ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      REQUESTED_FILES+=("$@")
+      break
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       usage >&2
       exit 2
       ;;
-    *) REQUESTED_FILES+=("$1"); shift ;;
+    *)
+      REQUESTED_FILES+=("$1")
+      shift
+      ;;
   esac
 done
 
-if ! command -v gcc >/dev/null 2>&1; then
+if ! command -v gcc > /dev/null 2>&1; then
   echo "gcc not found. Please install GCC." >&2
   exit 1
 fi
-if ! command -v g++ >/dev/null 2>&1; then
+if ! command -v g++ > /dev/null 2>&1; then
   echo "g++ not found. Please install G++." >&2
   exit 1
 fi
-if ! command -v python3 >/dev/null 2>&1; then
+if ! command -v python3 > /dev/null 2>&1; then
   echo "python3 not found. Please install python3." >&2
   exit 1
 fi
@@ -75,19 +91,19 @@ if [[ ! -f "$PDB_FILE" ]]; then
     PDB_FILE="compile_commands.json"
   else
     echo "Configuring CMake preset 'dev-debug' to generate compile_commands.json..."
-    cmake --preset dev-debug >/dev/null
+    cmake --preset dev-debug > /dev/null
     PDB_FILE="$PDB_DIR/compile_commands.json"
   fi
 fi
 
 if [[ -z "$JOBS" ]]; then
-  JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+  JOBS=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)
 fi
 
 LOG_FILE=".gcc-fanalyzer.local.out"
 
 set +e
-python3 - "$PDB_FILE" "$ROOT_DIR" "$STRICT" "$ALL_COMMANDS" "$JOBS" "${REQUESTED_FILES[@]}" <<'PY' 2>&1 | tee "$LOG_FILE"
+python3 - "$PDB_FILE" "$ROOT_DIR" "$STRICT" "$ALL_COMMANDS" "$JOBS" "${REQUESTED_FILES[@]}" << 'PY' 2>&1 | tee "$LOG_FILE"
 import concurrent.futures
 import json
 import os

--- a/tools/gitleaks.sh
+++ b/tools/gitleaks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/gitleaks.sh
+
+Runs Gitleaks against the repository and writes .gitleaks.sarif for code scanning.
+Uses a local gitleaks binary when present, otherwise falls back to Docker.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+LOG_FILE=".gitleaks.local.out"
+SARIF_FILE=".gitleaks.sarif"
+CONFIG_FILE=".gitleaks.toml"
+GITLEAKS_IMAGE="${MBE_GITLEAKS_IMAGE:-ghcr.io/gitleaks/gitleaks:v8.30.1}"
+
+ARGS=(
+  detect
+  --source=.
+  --config="$CONFIG_FILE"
+  --redact
+  --report-format=sarif
+  --report-path="$SARIF_FILE"
+  --exit-code=1
+  --no-banner
+)
+
+set +e
+if command -v gitleaks > /dev/null 2>&1; then
+  gitleaks "${ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+  rc=${PIPESTATUS[0]}
+elif command -v docker > /dev/null 2>&1; then
+  docker run --rm \
+    --volume "$ROOT_DIR:/repo" \
+    --workdir /repo \
+    "$GITLEAKS_IMAGE" \
+    "${ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+  rc=${PIPESTATUS[0]}
+else
+  echo "gitleaks not found and docker is unavailable." | tee "$LOG_FILE" >&2
+  rc=1
+fi
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  echo "Gitleaks completed. Full output in $LOG_FILE"
+else
+  echo "Gitleaks found issues or failed. See $LOG_FILE for details." >&2
+fi
+exit "$rc"

--- a/tools/install-git-hooks.sh
+++ b/tools/install-git-hooks.sh
@@ -20,5 +20,6 @@ if [[ -d "$hooks_dir" ]]; then
   shopt -u nullglob
 fi
 
-echo "Done. Commits auto-format staged C/C++ files; pushes run local CI-style strict checks (format, clang-tidy, cppcheck, iwyu, fanalyzer, semgrep, lizard, scan-build) on changed paths."
+echo "Done. Commits auto-format staged C/C++ files; pushes run local CI-style strict checks (format, CMake format, clang-tidy, cppcheck, iwyu, fanalyzer, semgrep, zizmor, OSV scan, shell/workflow lint, lizard) on changed paths."
 echo "Tip: run tools/preflight_ci.sh to execute the same local quality gates without pushing."
+echo "Tip: set MBE_HOOK_RUN_SCAN_BUILD=1 for the heavier full scan-build pass."

--- a/tools/iwyu.sh
+++ b/tools/iwyu.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 # - Excludes build/ and src/external/
 # - Optional strict mode fails on include suggestions
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/iwyu.sh [--strict] [--all-commands] [--jobs N] [--] [files...]
 
 Options:
@@ -32,8 +32,14 @@ REQUESTED_FILES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --strict) STRICT=1; shift ;;
-    --all-commands) ALL_COMMANDS=1; shift ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --all-commands)
+      ALL_COMMANDS=1
+      shift
+      ;;
     --jobs)
       if [[ $# -lt 2 ]]; then
         echo "Missing value for --jobs" >&2
@@ -42,22 +48,32 @@ while [[ $# -gt 0 ]]; do
       JOBS="$2"
       shift 2
       ;;
-    -h|--help) usage; exit 0 ;;
-    --) shift; REQUESTED_FILES+=("$@"); break ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      REQUESTED_FILES+=("$@")
+      break
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       usage >&2
       exit 2
       ;;
-    *) REQUESTED_FILES+=("$1"); shift ;;
+    *)
+      REQUESTED_FILES+=("$1")
+      shift
+      ;;
   esac
 done
 
-if ! command -v include-what-you-use >/dev/null 2>&1; then
+if ! command -v include-what-you-use > /dev/null 2>&1; then
   echo "include-what-you-use not found. Please install it (e.g., apt-get install iwyu)." >&2
   exit 1
 fi
-if ! command -v python3 >/dev/null 2>&1; then
+if ! command -v python3 > /dev/null 2>&1; then
   echo "python3 not found. Please install python3." >&2
   exit 1
 fi
@@ -71,19 +87,19 @@ if [[ ! -f "$PDB_FILE" ]]; then
     PDB_FILE="compile_commands.json"
   else
     echo "Configuring CMake preset 'dev-debug' to generate compile_commands.json..."
-    cmake --preset dev-debug >/dev/null
+    cmake --preset dev-debug > /dev/null
     PDB_FILE="$PDB_DIR/compile_commands.json"
   fi
 fi
 
 if [[ -z "$JOBS" ]]; then
-  JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+  JOBS=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)
 fi
 
 LOG_FILE=".iwyu.local.out"
 
 set +e
-python3 - "$PDB_FILE" "$ROOT_DIR" "$STRICT" "$ALL_COMMANDS" "$JOBS" "${REQUESTED_FILES[@]}" <<'PY' 2>&1 | tee "$LOG_FILE"
+python3 - "$PDB_FILE" "$ROOT_DIR" "$STRICT" "$ALL_COMMANDS" "$JOBS" "${REQUESTED_FILES[@]}" << 'PY' 2>&1 | tee "$LOG_FILE"
 import concurrent.futures
 import json
 import os

--- a/tools/lizard.sh
+++ b/tools/lizard.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 # Run Lizard complexity checks for project-owned code.
 # Strict mode fails when any Lizard threshold warning is emitted.
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/lizard.sh [--strict] [--ccn N] [--length N] [--arguments N] [--] [paths...]
 
 Options:
@@ -64,7 +64,7 @@ while [[ $# -gt 0 ]]; do
       ARGUMENTS_SET=1
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -93,7 +93,7 @@ if [[ $STRICT -eq 1 ]]; then
   [[ $ARGUMENTS_SET -eq 0 ]] && ARGUMENTS=13
 fi
 
-if ! command -v lizard >/dev/null 2>&1; then
+if ! command -v lizard > /dev/null 2>&1; then
   echo "lizard not found. Install with: python -m pip install lizard." >&2
   exit 1
 fi

--- a/tools/osv_scan.sh
+++ b/tools/osv_scan.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/osv_scan.sh [--sarif-out FILE] [--] [paths...]
+
+Runs OSV-Scanner source dependency/vendored-code scanning.
+Default path: .
+
+Environment:
+  MBE_OSV_SCANNER_IMAGE       Docker image fallback (default: ghcr.io/google/osv-scanner:v2.3.1)
+  MBE_OSV_SARIF_OUT           Optional SARIF output path.
+  MBE_OSV_ALLOW_NO_PACKAGES   Treat missing package metadata/lockfiles as success (default: 1).
+USAGE
+}
+
+SARIF_OUT="${MBE_OSV_SARIF_OUT:-}"
+TARGETS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sarif-out)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --sarif-out" >&2
+        exit 2
+      fi
+      SARIF_OUT="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      TARGETS+=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      TARGETS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(.)
+fi
+
+OSV_IMAGE="${MBE_OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.1}"
+ALLOW_NO_PACKAGES="${MBE_OSV_ALLOW_NO_PACKAGES:-1}"
+LOG_FILE=".osv-scanner.local.out"
+
+run_osv() {
+  local format="$1"
+  local output_file="${2:-}"
+  local args=(scan source --recursive --format "$format" --verbosity error)
+  if [[ "$ALLOW_NO_PACKAGES" == "1" ]]; then
+    args+=(--allow-no-lockfiles)
+  fi
+  if [[ -n "$output_file" ]]; then
+    args+=(--output "$output_file")
+  fi
+  args+=("${TARGETS[@]}")
+
+  if command -v osv-scanner > /dev/null 2>&1; then
+    osv-scanner "${args[@]}"
+  elif command -v docker > /dev/null 2>&1; then
+    docker run --rm \
+      --volume "$ROOT_DIR:/src" \
+      --workdir /src \
+      "$OSV_IMAGE" \
+      "${args[@]}"
+  else
+    echo "osv-scanner not found and docker is unavailable." >&2
+    return 127
+  fi
+}
+
+normalize_rc() {
+  local rc="$1"
+  if [[ "$ALLOW_NO_PACKAGES" == "1" && "$rc" -eq 128 ]]; then
+    echo "OSV-Scanner found no supported package metadata; treating as success." >&2
+    return 0
+  fi
+  return "$rc"
+}
+
+set +e
+{
+  echo "OSV-Scanner targets: ${TARGETS[*]}"
+  run_osv vertical
+} 2>&1 | tee "$LOG_FILE"
+plain_rc=${PIPESTATUS[0]}
+normalize_rc "$plain_rc"
+plain_rc=$?
+
+sarif_rc=0
+if [[ -n "$SARIF_OUT" ]]; then
+  run_osv sarif "$SARIF_OUT" >> "$LOG_FILE" 2>&1
+  sarif_rc=$?
+  normalize_rc "$sarif_rc"
+  sarif_rc=$?
+fi
+set -e
+
+rc=$plain_rc
+if [[ $rc -eq 0 && $sarif_rc -ne 0 ]]; then
+  rc=$sarif_rc
+fi
+
+if [[ $rc -eq 0 ]]; then
+  echo "OSV-Scanner completed. Full output in $LOG_FILE"
+else
+  echo "OSV-Scanner found issues or failed. See $LOG_FILE for details." >&2
+fi
+exit "$rc"

--- a/tools/preflight_ci.sh
+++ b/tools/preflight_ci.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Also checks uncommitted (staged/unstaged/untracked) local changes.
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/preflight_ci.sh [--remote <name>] [--base <ref-or-sha>]
 
 Runs pre-push checks for the push delta and current uncommitted changes.
@@ -18,6 +18,7 @@ Options:
 
 Environment:
   MBE_HOOK_FAIL_ON_MISSING_TOOLS=1|0
+  MBE_HOOK_RUN_SCAN_BUILD=1|0
 
 Examples:
   tools/preflight_ci.sh
@@ -46,7 +47,7 @@ while [[ $# -gt 0 ]]; do
       BASE_REF="$2"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -58,7 +59,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+repo_root=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$repo_root"
 
 hook_path=".githooks/pre-push"
@@ -72,14 +73,14 @@ zeros="0000000000000000000000000000000000000000"
 
 local_ref=$(git symbolic-ref -q HEAD || echo "HEAD")
 local_sha=$(git rev-parse HEAD)
-branch_name=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+branch_name=$(git rev-parse --abbrev-ref HEAD 2> /dev/null || echo "HEAD")
 remote_ref="refs/heads/${branch_name}"
 remote_sha="$zeros"
 
-upstream_ref=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null || true)
+upstream_ref=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2> /dev/null || true)
 
 if [[ -n "$BASE_REF" ]]; then
-  if ! remote_sha=$(git rev-parse "$BASE_REF" 2>/dev/null); then
+  if ! remote_sha=$(git rev-parse "$BASE_REF" 2> /dev/null); then
     echo "Unable to resolve --base reference: $BASE_REF" >&2
     exit 2
   fi
@@ -89,7 +90,7 @@ fi
 if [[ -z "$REMOTE_NAME" ]]; then
   if [[ -n "$upstream_ref" ]]; then
     REMOTE_NAME="${upstream_ref%%/*}"
-  elif git remote get-url origin >/dev/null 2>&1; then
+  elif git remote get-url origin > /dev/null 2>&1; then
     REMOTE_NAME="origin"
   else
     REMOTE_NAME="$(git remote | head -n 1 || true)"
@@ -109,13 +110,13 @@ if [[ -z "$BASE_REF" && -n "$upstream_ref" ]]; then
   upstream_remote="${upstream_ref%%/*}"
   upstream_branch="${upstream_ref#*/}"
   if [[ "$upstream_remote" == "$REMOTE_NAME" ]]; then
-    if remote_sha=$(git rev-parse "$upstream_ref" 2>/dev/null); then
+    if remote_sha=$(git rev-parse "$upstream_ref" 2> /dev/null); then
       remote_ref="refs/heads/${upstream_branch}"
     fi
   fi
 fi
 
-remote_url=$(git remote get-url "$REMOTE_NAME" 2>/dev/null || true)
+remote_url=$(git remote get-url "$REMOTE_NAME" 2> /dev/null || true)
 
 echo "preflight: local_ref=${local_ref} local_sha=${local_sha}"
 echo "preflight: remote=${REMOTE_NAME} remote_ref=${remote_ref} remote_sha=${remote_sha}"
@@ -136,12 +137,12 @@ head_tree=$(git rev-parse "${local_sha}^{tree}")
 
 if [[ "$worktree_tree" != "$head_tree" ]]; then
   worktree_sha=$(
-    printf 'preflight_ci synthetic worktree commit\n' | \
+    printf 'preflight_ci synthetic worktree commit\n' |
       GIT_AUTHOR_NAME=mbelib-neo-preflight \
-      GIT_AUTHOR_EMAIL=preflight@local \
-      GIT_COMMITTER_NAME=mbelib-neo-preflight \
-      GIT_COMMITTER_EMAIL=preflight@local \
-      git commit-tree "$worktree_tree" -p "$local_sha"
+        GIT_AUTHOR_EMAIL=preflight@local \
+        GIT_COMMITTER_NAME=mbelib-neo-preflight \
+        GIT_COMMITTER_EMAIL=preflight@local \
+        git commit-tree "$worktree_tree" -p "$local_sha"
   )
   echo "preflight: running checks for uncommitted local changes"
   printf '%s %s %s %s\n' "$local_ref" "$worktree_sha" "$local_ref" "$local_sha" | "$hook_path" "$REMOTE_NAME" "$remote_url"

--- a/tools/quality_preflight.sh
+++ b/tools/quality_preflight.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+export MBE_HOOK_FAIL_ON_MISSING_TOOLS=1
+export MBE_HOOK_RUN_SCAN_BUILD=1
+
+tools/preflight_ci.sh "$@"
+tools/cmake_format_check.sh
+tools/shell_lint.sh
+tools/workflow_lint.sh
+tools/zizmor.sh
+tools/osv_scan.sh
+tools/gitleaks.sh

--- a/tools/scan_build.sh
+++ b/tools/scan_build.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 # Intended for CI or explicit local runs (heavier than per-file analyzers).
 # Excludes third-party code under src/external.
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/scan_build.sh [--strict] [--jobs N] [--build-dir DIR] [--output-dir DIR]
 
 Options:
@@ -27,7 +27,10 @@ OUTPUT_DIR=".scan-build.local"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --strict) STRICT=1; shift ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
     --jobs)
       if [[ $# -lt 2 ]]; then
         echo "Missing value for --jobs" >&2
@@ -52,7 +55,10 @@ while [[ $# -gt 0 ]]; do
       OUTPUT_DIR="$2"
       shift 2
       ;;
-    -h|--help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
     *)
       echo "Unknown option: $1" >&2
       usage >&2
@@ -61,22 +67,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if ! command -v scan-build >/dev/null 2>&1; then
+if ! command -v scan-build > /dev/null 2>&1; then
   echo "scan-build not found. Please install clang-tools." >&2
   exit 1
 fi
-if ! command -v cmake >/dev/null 2>&1; then
+if ! command -v cmake > /dev/null 2>&1; then
   echo "cmake not found. Please install cmake." >&2
   exit 1
 fi
 
 print_scan_build_version() {
-  if scan-build --version >/dev/null 2>&1; then
+  if scan-build --version > /dev/null 2>&1; then
     scan-build --version
     return 0
   fi
 
-  if scan-build -version >/dev/null 2>&1; then
+  if scan-build -version > /dev/null 2>&1; then
     scan-build -version
     return 0
   fi
@@ -86,7 +92,7 @@ print_scan_build_version() {
 }
 
 if [[ -z "$JOBS" ]]; then
-  JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+  JOBS=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)
 fi
 
 LOG_FILE=".scan-build.local.out"

--- a/tools/semgrep.sh
+++ b/tools/semgrep.sh
@@ -3,22 +3,27 @@ set -euo pipefail
 
 # Run Semgrep for additional SAST checks. Default mode is advisory (non-erroring).
 # Use --strict to fail on findings.
-# Excludes third-party code under src/external.
+# Excludes third-party code under src/external. Strict mode also loads
+# project-specific guardrail rules from semgrep/mbelib-neo.yml.
 
-ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
 
 usage() {
-  cat <<'USAGE'
+  cat << 'USAGE'
 Usage: tools/semgrep.sh [--strict] [--config <config>] [--] [paths...]
 
 Options:
   --strict          Fail on findings (--error).
   --config CONFIG   Semgrep config/rule pack (default: p/default; strict also
-                    adds p/c and p/security-audit). May be supplied multiple times.
+                    adds p/c, p/security-audit, and semgrep/mbelib-neo.yml).
+                    May be supplied multiple times.
 
 Arguments:
-  paths...          Optional paths to scan. Default: src include examples bench tests tools
+  paths...          Optional paths to scan. Default: src include examples bench tests tools .github/workflows
+
+Environment:
+  MBE_SEMGREP_SARIF_OUT  Optional SARIF output path for GitHub code scanning.
 USAGE
 }
 
@@ -29,7 +34,10 @@ TARGETS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --strict) STRICT=1; shift ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
     --config)
       if [[ $# -lt 2 ]]; then
         echo "Missing value for --config" >&2
@@ -42,24 +50,34 @@ while [[ $# -gt 0 ]]; do
       CONFIGS+=("$2")
       shift 2
       ;;
-    -h|--help) usage; exit 0 ;;
-    --) shift; TARGETS+=("$@"); break ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      TARGETS+=("$@")
+      break
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       usage >&2
       exit 2
       ;;
-    *) TARGETS+=("$1"); shift ;;
+    *)
+      TARGETS+=("$1")
+      shift
+      ;;
   esac
 done
 
-if ! command -v semgrep >/dev/null 2>&1; then
+if ! command -v semgrep > /dev/null 2>&1; then
   echo "semgrep not found. Install with: pipx install semgrep (or pip install semgrep)." >&2
   exit 1
 fi
 
 if [[ ${#TARGETS[@]} -eq 0 ]]; then
-  TARGETS=(src include examples bench tests tools)
+  TARGETS=(src include examples bench tests tools .github/workflows)
 fi
 
 LOG_FILE=".semgrep.local.out"
@@ -67,19 +85,26 @@ LOG_FILE=".semgrep.local.out"
 ARGS=(
   --metrics=off
   --disable-version-check
+  --no-git-ignore
+  --exclude .deps-arch-toolchain
+  --exclude .deps-arch-toolchain/**
   --exclude src/external
   --exclude src/external/**
   --exclude build
+  --exclude build/**
 )
 if [[ $STRICT -eq 1 ]]; then
   ARGS+=(--error)
   if [[ $CUSTOM_CONFIGS -eq 0 ]]; then
-    CONFIGS+=(p/c p/security-audit)
+    CONFIGS+=(p/c p/security-audit semgrep/mbelib-neo.yml)
   fi
 fi
 for config in "${CONFIGS[@]}"; do
   ARGS+=(--config "$config")
 done
+if [[ -n "${MBE_SEMGREP_SARIF_OUT:-}" ]]; then
+  ARGS+=(--sarif --output "$MBE_SEMGREP_SARIF_OUT")
+fi
 
 set +e
 semgrep "${ARGS[@]}" "${TARGETS[@]}" 2>&1 | tee "$LOG_FILE"

--- a/tools/shell_lint.sh
+++ b/tools/shell_lint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/shell_lint.sh [--] [files...]
+
+Runs shellcheck and shfmt in diff/check mode for repository shell scripts.
+When no files are supplied, tracked shell scripts and git hooks are checked.
+USAGE
+}
+
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      FILES+=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! command -v shellcheck > /dev/null 2>&1; then
+  echo "shellcheck not found. Install shellcheck to run shell linting." >&2
+  exit 1
+fi
+if ! command -v shfmt > /dev/null 2>&1; then
+  echo "shfmt not found. Install shfmt to run shell formatting checks." >&2
+  exit 1
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  mapfile -t FILES < <(
+    {
+      git ls-files '*.sh' '.githooks/*'
+      git ls-files --others --exclude-standard -- '*.sh' '.githooks/*'
+      git grep -Il '^#!.*sh' -- ':!build/**' ':!src/external/**' || true
+    } | sort -u
+  )
+fi
+
+FILTERED=()
+for f in "${FILES[@]}"; do
+  case "$f" in
+    build/* | src/external/*) continue ;;
+  esac
+  if [[ -f "$f" ]]; then
+    FILTERED+=("$f")
+  fi
+done
+
+if [[ ${#FILTERED[@]} -eq 0 ]]; then
+  echo "No shell scripts to lint."
+  exit 0
+fi
+
+LOG_FILE=".shell-lint.local.out"
+set +e
+{
+  echo "shellcheck files: ${#FILTERED[@]}"
+  shellcheck "${FILTERED[@]}"
+  echo "shfmt files: ${#FILTERED[@]}"
+  shfmt -d -i 2 -ci -sr "${FILTERED[@]}"
+} 2>&1 | tee "$LOG_FILE"
+rc=${PIPESTATUS[0]}
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  echo "Shell lint completed. Full output in $LOG_FILE"
+else
+  echo "Shell lint failed. See $LOG_FILE for details." >&2
+fi
+exit "$rc"

--- a/tools/workflow_lint.sh
+++ b/tools/workflow_lint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/workflow_lint.sh [--] [workflow-files...]
+
+Runs actionlint over GitHub Actions workflow files.
+USAGE
+}
+
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      FILES+=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! command -v actionlint > /dev/null 2>&1; then
+  echo "actionlint not found. Install actionlint to lint GitHub Actions workflows." >&2
+  exit 1
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  mapfile -t FILES < <(
+    {
+      git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml'
+      git ls-files --others --exclude-standard -- '.github/workflows/*.yml' '.github/workflows/*.yaml'
+    } | sort -u
+  )
+fi
+
+FILTERED=()
+for f in "${FILES[@]}"; do
+  if [[ -f "$f" ]]; then
+    FILTERED+=("$f")
+  fi
+done
+
+if [[ ${#FILTERED[@]} -eq 0 ]]; then
+  echo "No workflow files to lint."
+  exit 0
+fi
+
+LOG_FILE=".actionlint.local.out"
+set +e
+actionlint "${FILTERED[@]}" 2>&1 | tee "$LOG_FILE"
+rc=${PIPESTATUS[0]}
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  echo "Workflow lint completed. Full output in $LOG_FILE"
+else
+  echo "Workflow lint failed. See $LOG_FILE for details." >&2
+fi
+exit "$rc"

--- a/tools/zizmor.sh
+++ b/tools/zizmor.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$ROOT_DIR"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/zizmor.sh [--pedantic|--auditor] [--min-confidence LEVEL] [--min-severity LEVEL] [--sarif-out FILE] [--no-config] [--] [inputs...]
+
+Runs zizmor against GitHub Actions workflows and Dependabot config.
+Default inputs: .github/workflows .github/dependabot.yml
+
+Environment:
+  MBE_ZIZMOR_SARIF_OUT  Optional SARIF output path.
+USAGE
+}
+
+PERSONA="regular"
+MIN_CONFIDENCE="high"
+MIN_SEVERITY="low"
+SARIF_OUT="${MBE_ZIZMOR_SARIF_OUT:-}"
+NO_CONFIG=0
+INPUTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pedantic)
+      PERSONA="pedantic"
+      shift
+      ;;
+    --auditor)
+      PERSONA="auditor"
+      shift
+      ;;
+    --min-confidence)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --min-confidence" >&2
+        exit 2
+      fi
+      MIN_CONFIDENCE="$2"
+      shift 2
+      ;;
+    --min-severity)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --min-severity" >&2
+        exit 2
+      fi
+      MIN_SEVERITY="$2"
+      shift 2
+      ;;
+    --sarif-out)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --sarif-out" >&2
+        exit 2
+      fi
+      SARIF_OUT="$2"
+      shift 2
+      ;;
+    --no-config)
+      NO_CONFIG=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      INPUTS+=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      INPUTS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! command -v zizmor > /dev/null 2>&1; then
+  echo "zizmor not found. Install with: pipx install zizmor (or python -m pip install zizmor)." >&2
+  exit 1
+fi
+
+if [[ ${#INPUTS[@]} -eq 0 ]]; then
+  INPUTS=(.github/workflows .github/dependabot.yml)
+fi
+
+COMMON_ARGS=(
+  --offline
+  --persona="$PERSONA"
+  --min-confidence="$MIN_CONFIDENCE"
+  --no-progress
+  --color=never
+)
+if [[ -n "$MIN_SEVERITY" ]]; then
+  COMMON_ARGS+=(--min-severity="$MIN_SEVERITY")
+fi
+if [[ $NO_CONFIG -eq 1 ]]; then
+  COMMON_ARGS+=(--no-config)
+fi
+
+LOG_FILE=".zizmor.local.out"
+ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/mbelib-neo-zizmor-sarif.XXXXXX")"
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
+cleanup() {
+  rm -f "$ERR_FILE"
+}
+trap cleanup EXIT
+
+set +e
+zizmor "${COMMON_ARGS[@]}" --format=plain "${INPUTS[@]}" 2>&1 | tee "$LOG_FILE"
+plain_rc=${PIPESTATUS[0]}
+
+sarif_rc=0
+if [[ -n "$SARIF_OUT" ]]; then
+  zizmor "${COMMON_ARGS[@]}" --format=sarif "${INPUTS[@]}" > "$SARIF_OUT" 2> "$ERR_FILE"
+  sarif_rc=$?
+  if [[ -s "$ERR_FILE" ]]; then
+    cat "$ERR_FILE" >> "$LOG_FILE"
+  fi
+fi
+set -e
+
+rc=$plain_rc
+if [[ $rc -eq 0 && $sarif_rc -ne 0 ]]; then
+  rc=$sarif_rc
+fi
+
+if [[ $rc -eq 0 ]]; then
+  echo "zizmor completed. Full output in $LOG_FILE"
+else
+  echo "zizmor found issues or failed. See $LOG_FILE for details." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

- Align mbelib-neo with the relevant dsd-neo lint, security, settings, CodeQL, and supply-chain guardrails.
- Add SHA-pinned GitHub Actions, CodeQL security-and-quality manual build analysis, guardrails and Scorecard workflows, and Dependabot cadence/labels.
- Add SECURITY.md, CODEOWNERS, PR template, guardrail docs, project Semgrep rules, and local wrappers for shell/workflow/CMake lint, zizmor, Gitleaks, OSV, changed-file targeting, and quality preflight.
- Apply shell and CMake formatting so the new gates pass on the current tree.

## Validation

- `tools/shell_lint.sh`
- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- `tools/semgrep.sh --strict`
- `tools/gitleaks.sh`
- `tools/osv_scan.sh`
- `tools/preflight_ci.sh --base HEAD`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `cmake --preset dev-debug -DMBELIB_WARNINGS_AS_ERRORS=ON`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/scan_build.sh --strict`
- SHA-pin audit for workflow `uses:` refs
- `git diff --check`

## Notes

- This intentionally includes mechanical shell and CMake formatting because those checks are now hard guardrails.