### PR TITLE
add OpenSSF Silver policy documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a reproducible defect in mbelib-neo
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Version
+
+- mbelib-neo version/tag/commit:
+- Operating system:
+- Compiler:
+- CMake preset or build command:
+
+## Reproduction
+
+Steps or minimal code needed to reproduce the issue:
+
+```text
+
+```
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Logs or Output
+
+```text
+
+```
+
+## Safety Check
+
+- [ ] This report does not include private captures, credentials, keys, or
+      machine-specific configuration.
+- [ ] This is not a private security vulnerability report. Security issues must
+      use `SECURITY.md`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Private vulnerability report
+    url: https://github.com/arancormonk/mbelib-neo/security/advisories/new
+    about: Report suspected security vulnerabilities privately.
+  - name: Discussions
+    url: https://github.com/arancormonk/mbelib-neo/discussions
+    about: Ask usage questions or discuss ideas before filing an issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
 - [ ] Risky or broad changes have a second reviewer.
 - [ ] Copied, generated, or bulk-written code has been read, understood, and adapted to mbelib-neo conventions.
+- [ ] Non-trivial commits include DCO `Signed-off-by` lines.
 
 ## Quality Review
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ Thumbs.db
 /*.md
 !/README.md
 !/SECURITY.md
+!/CODE_OF_CONDUCT.md
+!/CONTRIBUTING.md
+!/GOVERNANCE.md
+!/ROADMAP.md
+!/SUPPORT.md
 
 # Log files
 /logs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,20 @@ if(MBELIB_BUILD_TESTS)
     endif()
     add_test(NAME test_params COMMAND test_params)
 
+    add_executable(test_frame_paths tests/test_frame_paths.c)
+    target_link_libraries(test_frame_paths PRIVATE ${MBELIB_EXEC_LINK_TGT})
+    target_include_directories(
+        test_frame_paths
+        PRIVATE "${PROJECT_SOURCE_DIR}/include"
+    )
+    if(_SAN_CFLAGS)
+        target_compile_options(test_frame_paths PRIVATE ${_SAN_CFLAGS})
+    endif()
+    if(_SAN_LDFLAGS)
+        target_link_options(test_frame_paths BEFORE PRIVATE ${_SAN_LDFLAGS})
+    endif()
+    add_test(NAME test_frame_paths COMMAND test_frame_paths)
+
     add_executable(test_floattoshort_parity tests/test_floattoshort_parity.c)
     target_link_libraries(
         test_floattoshort_parity

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+mbelib-neo uses a simple contributor code of conduct to keep project discussion
+focused, respectful, and useful.
+
+## Expected Behavior
+
+- Be respectful of differing experience levels and viewpoints.
+- Keep technical disagreement focused on facts, code, tests, and project goals.
+- Give actionable feedback and assume public discussions are archived.
+- Disclose conflicts of interest when they materially affect a proposal or
+  review.
+- Respect private vulnerability reports and embargoed security information.
+
+## Unacceptable Behavior
+
+- Harassment, threats, personal attacks, or sustained disruption.
+- Publishing private contact information, credentials, private captures, or
+  security-sensitive information without permission.
+- Spam, abusive automation, or repeated off-topic comments.
+- Retaliation against someone for reporting a conduct, safety, or security
+  concern.
+
+## Enforcement
+
+The maintainer may edit or remove comments, close issues or pull requests, block
+accounts, or restrict participation when behavior is harmful to the project.
+
+Report conduct concerns privately to the maintainer through GitHub:
+
+https://github.com/arancormonk
+
+Security vulnerabilities are handled separately through `SECURITY.md`.
+
+## Scope
+
+This code of conduct applies to project-controlled spaces, including the GitHub
+repository, issues, pull requests, discussions, release notes, and any project
+communication channel linked from the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to mbelib-neo
+
+mbelib-neo accepts changes through GitHub issues and pull requests. Keep changes
+small, focused, and reviewable.
+
+## Contribution Process
+
+1. Open or reference an issue for user-visible behavior changes, API changes,
+   dependency changes, release changes, and security-sensitive work.
+2. Create a branch from `main`.
+3. Make the smallest coherent change that solves the problem.
+4. Add or update tests and documentation when behavior, public API, build
+   behavior, release behavior, or security posture changes.
+5. Run the relevant local checks before opening a pull request.
+6. Open a pull request against `main` and complete the pull request template.
+7. Address review comments and wait for required CI checks to pass before merge.
+
+Security vulnerabilities must not be reported through public issues or pull
+requests. Use the private reporting process in `SECURITY.md`.
+
+## Legal Certification
+
+Non-trivial contributions must use the Developer Certificate of Origin 1.1
+sign-off. Add this line to each commit message:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The sign-off means you certify that you have the right to submit the work under
+the project's license. The DCO text is published at:
+
+https://developercertificate.org/
+
+Use `git commit -s` to add the sign-off automatically.
+
+## Acceptable Contribution Requirements
+
+A contribution is acceptable only when it meets the requirements below or the
+pull request explains why an exception is appropriate.
+
+- The change is compatible with GPL-2.0-or-later and does not introduce license
+  conflicts.
+- Project-maintained source files include an SPDX license identifier near the
+  top of the file.
+- New or changed public API is documented in `include/mbelib-neo/` comments and
+  in user-facing documentation when needed.
+- Major functionality changes include focused automated tests.
+- Bug fixes include regression tests when practical.
+- Generated build outputs, compiled binaries, private captures, credentials,
+  keys, and machine-specific configuration are not committed.
+- Vendored third-party code is placed under `src/external/`, keeps upstream
+  license notices, and is documented in dependency records.
+- Workflow, dependency, packaging, release, codec, DSP, public API, and security
+  changes receive extra review.
+- Static-analysis suppressions are narrow and explain why the local exception is
+  acceptable.
+
+## Coding Standards
+
+The project uses C99 and CMake.
+
+- C code follows the repository `.clang-format` configuration, based on LLVM
+  style with 4-space indentation and a 120-column limit.
+- CMake files are formatted with `gersemi` through
+  `tools/cmake_format_check.sh`.
+- Public symbols use the `mbe_` prefix unless compatibility requires otherwise.
+- Keep internal symbols `static` where practical.
+- Avoid direct inclusion of bundled third-party headers outside approved
+  integration points.
+- Do not spawn shells or external processes from project-owned C code without
+  explicit design review.
+
+Run formatting with:
+
+```sh
+tools/format.sh
+```
+
+## Tests and Local Checks
+
+Run the smallest useful check set for the change, then broaden it for risky
+changes.
+
+```sh
+cmake --preset dev-debug
+cmake --build --preset dev-debug -j
+ctest --preset dev-debug --output-on-failure
+```
+
+Normal pre-push check:
+
+```sh
+tools/preflight_ci.sh
+```
+
+Broad or high-risk changes:
+
+```sh
+tools/quality_preflight.sh
+```
+
+Additional focused checks:
+
+- CMake changes: `tools/cmake_format_check.sh`
+- Workflow changes: `tools/workflow_lint.sh` and `tools/zizmor.sh`
+- Dependency input changes: `tools/osv_scan.sh`
+- Sanitizer-sensitive code: configure and build `asan-ubsan-debug`, then run
+  `ctest --preset asan-ubsan-debug --output-on-failure`
+
+## Test Policy
+
+Major new functionality must add or update automated tests. For this project,
+"major" includes public API changes, codec behavior changes, DSP changes,
+dependency updates that affect compiled code, security-sensitive behavior,
+workflow changes that gate releases, and packaging/install changes.
+
+The preferred test style is a focused regression test under `tests/` that can
+run through CTest. If a behavior cannot be tested directly, the pull request
+must explain the reason and include the best practical substitute, such as a
+golden hash, build/install consumer check, analyzer rule, or fuzz target update.
+
+## Review Requirements
+
+Every pull request is reviewed for:
+
+- correctness and compatibility with surrounding module design
+- security impact, including input handling and dependency changes
+- API and ABI compatibility
+- licensing and attribution
+- test coverage and documentation coverage
+- packaging and release impact
+
+Risky or broad changes should receive a second human review before merge.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,104 @@
+# Governance
+
+mbelib-neo is maintained as a small, maintainer-led open source project.
+
+## Decision Model
+
+The project uses maintainer consensus where possible. For routine changes, a
+maintainer may merge a pull request after the required checks pass and review
+concerns are addressed.
+
+For broad or risky changes, the maintainer should wait for additional review or
+public discussion before merging. Risky changes include:
+
+- public API or ABI changes
+- codec, DSP, or external-input handling changes
+- dependency, vendored-code, or licensing changes
+- CI/CD, release, signing, or packaging changes
+- security policy or vulnerability-handling changes
+
+If consensus is not reached, the maintainer makes the final decision and should
+document the rationale in the issue or pull request.
+
+## Roles and Responsibilities
+
+### Maintainer
+
+Current maintainer: `@arancormonk`
+
+Responsibilities:
+
+- triage issues and pull requests
+- review and merge changes
+- maintain CI/CD and release automation
+- publish releases
+- manage repository settings and branch protection
+- handle private vulnerability reports
+- maintain project documentation and roadmap
+- decide whether proposed work is in scope
+
+### Security Contact
+
+Current security contact: `@arancormonk` through GitHub private vulnerability
+reporting.
+
+Responsibilities:
+
+- acknowledge private vulnerability reports
+- coordinate fixes and disclosure
+- request additional information when needed
+- publish advisories or release notes for confirmed vulnerabilities
+- credit reporters unless anonymity is requested
+
+### Contributor
+
+Responsibilities:
+
+- follow `CONTRIBUTING.md`
+- certify non-trivial contributions with DCO sign-off
+- add tests and documentation for meaningful behavior changes
+- keep pull requests focused and reviewable
+- avoid public disclosure of private security reports
+
+## Sensitive Resources
+
+Sensitive project resources include:
+
+- GitHub repository administration
+- GitHub private vulnerability reports and draft advisories
+- release signing keys
+- package publication credentials
+- GitHub Actions secrets
+- AUR publication credentials
+
+Access to sensitive resources is limited to the maintainer and any explicitly
+approved backup or successor. New access must be intentionally granted and
+reviewed before elevation.
+
+## Access Continuity
+
+The project is designed to continue with minimal interruption if the maintainer
+is unavailable.
+
+The maintainer must keep an offline emergency access packet for a trusted
+successor. The packet should include:
+
+- repository recovery instructions
+- release and package publication instructions
+- location of release signing public keys
+- instructions for rotating or revoking secrets
+- authority to appoint or transfer maintainership if the maintainer is
+  confirmed unavailable
+
+The trusted successor does not need routine project access, but must be able to
+help recover enough access to create and close issues, accept proposed changes,
+and publish a release within one week after unavailability is confirmed.
+
+Do not publish private keys, recovery codes, personal emergency contacts, or
+secret locations in the repository.
+
+## Bus Factor
+
+The current public bus factor is one maintainer. This is intentionally documented
+so users can evaluate continuity risk. The roadmap includes reducing this risk by
+recruiting reviewers and potential backup maintainers.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Performance‑enhanced IMBE/AMBE vocoder primitives with a modern CMake build, i
 Project homepage: https://github.com/arancormonk/mbelib-neo
 
 [![CI](https://github.com/arancormonk/mbelib-neo/actions/workflows/ci.yml/badge.svg)](https://github.com/arancormonk/mbelib-neo/actions/workflows/ci.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12975/badge)](https://www.bestpractices.dev/projects/12975)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12975/baseline)](https://www.bestpractices.dev/projects/12975)
 
 ## Patent Notice
 
@@ -106,6 +108,7 @@ GitHub Actions builds release package artifacts when you push a tag matching `vX
 The tag must match the project version declared in `CMakeLists.txt`, or the release workflow fails before packaging.
 
 On a matching tag, CI rebuilds `dev-release`, reruns the release preset tests, and packages the installed library tree for Linux, macOS, and Windows. Release publication is a maintainer action after the package artifacts and checks have been reviewed.
+Release verification instructions are in `docs/release-verification.md`.
 
 Typical release flow:
 
@@ -350,6 +353,24 @@ cmake --build --preset dev-debug --target docs
 
 The generated site focuses on the public API (`include/`) and bundled examples.
 
+Project documentation and policies:
+
+- Contribution process, DCO, coding standards, review requirements, and test policy: `CONTRIBUTING.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
+- Governance, roles, responsibilities, sensitive-resource access, and continuity: `GOVERNANCE.md`
+- Roadmap and scope: `ROADMAP.md`
+- Support and upgrade policy: `SUPPORT.md`
+- Defect reporting: `docs/issue-reporting.md`
+- Architecture and trust boundaries: `docs/architecture.md`
+- Build and installation policy: `docs/build-installation.md`
+- Security requirements and assurance: `docs/security-requirements.md`
+- Dependency management and monitoring: `docs/dependencies.md`
+- Project site, accessibility, and localization: `docs/project-site-and-localization.md`
+- Testing, CI, coverage target, and dynamic analysis: `docs/testing.md`
+- Release verification and signing: `docs/release-verification.md`
+- Supply-chain guardrails: `docs/supply-chain-guardrails.md`
+- Code-quality guardrails: `docs/code-quality-guardrails.md`
+
 ## Project Layout
 
 - Public headers: `include/mbelib-neo/`
@@ -361,6 +382,7 @@ The generated site focuses on the public API (`include/`) and bundled examples.
 
 ## Contributing
 
+- Read `CONTRIBUTING.md` before opening a pull request.
 - Follow `.clang-format` (LLVM style, 4‑space indent, 120 cols). You can run `tools/format.sh`.
 - Static analysis scripts (CI-aligned; CI and pre-push/preflight use strict mode where applicable):
   - `tools/clang_tidy.sh` (strict promotes broad bugprone/performance/portability findings; targeted TUs supported).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,54 @@
+# Roadmap
+
+This roadmap covers the next year of mbelib-neo maintenance and development.
+It is a planning document, not a promise that every item will ship.
+
+## Current Scope
+
+mbelib-neo provides C library primitives for IMBE/AMBE vocoder frame handling,
+error correction, synthesis, packaging, tests, and developer tooling.
+
+The project intends to remain:
+
+- a C library with installable headers
+- compatible with CMake and pkg-config consumers
+- focused on AMBE/IMBE codec primitives and related synthesis behavior
+- testable through CTest and GitHub Actions
+- conservative about new runtime dependencies
+
+## 2026 Priorities
+
+- Stabilize the 2.x API and ABI after the v2.0.0 ABI break.
+- Keep release packaging working across Linux, macOS, and Windows.
+- Improve public API documentation and generated Doxygen output.
+- Expand regression tests for soft-decision decode paths, error handling, and
+  synthesis edge cases.
+- Keep static analysis, fuzzing, dependency review, and secret scanning active
+  in CI.
+- Improve release verification documentation and release artifact provenance.
+- Reduce project continuity risk by recruiting additional reviewers or backup
+  maintainers.
+
+## Out of Scope for the Next Year
+
+- Implementing patented codec encoders or patent-clearing downstream use cases.
+- Adding network services, daemon modes, or user account management.
+- Adding non-FLOSS runtime dependencies.
+- Replacing CMake as the primary build system.
+- Guaranteeing bit-identical floating-point audio across all compilers,
+  architectures, and optimization settings.
+- Providing legal advice about patent licensing or jurisdiction-specific use.
+
+## Compatibility Policy
+
+- Patch releases should preserve source and binary compatibility within the same
+  major version.
+- Minor releases should preserve ABI unless release notes explicitly say
+  otherwise.
+- Major releases may break ABI and must document migration notes.
+
+## Maintenance Policy
+
+Security fixes are handled on the default branch and latest tagged release line.
+Older releases may receive fixes when the maintainer determines that the impact
+and user base justify the work.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,7 @@
 ## Supported Versions
 
 Security fixes are handled on the default branch and the latest tagged release line.
+See `SUPPORT.md` for the support and upgrade policy.
 
 ## Reporting A Vulnerability
 
@@ -21,6 +22,28 @@ If you need to coordinate before filing, use a draft GitHub Security Advisory. I
 - whether the issue may expose credentials, keys, captures, or user data
 
 The maintainer will acknowledge valid reports through the private GitHub security channel and coordinate disclosure there.
+
+## Response Process
+
+The maintainer will:
+
+1. Acknowledge valid vulnerability reports within 14 days.
+2. Triage impact, affected versions, exploitability, and available mitigations.
+3. Develop fixes privately when public disclosure would increase user risk.
+4. Coordinate disclosure timing with the reporter when practical.
+5. Publish a fixed release, advisory, or release note for confirmed
+   vulnerabilities.
+6. Credit reporters unless anonymity is requested.
+
+Reports that cannot be reproduced or do not affect mbelib-neo will be closed
+with an explanation when possible.
+
+## Public Vulnerability Information
+
+Confirmed vulnerabilities are published through GitHub Security Advisories,
+release notes, or both. Public entries should include affected versions,
+mitigation or upgrade guidance, and reporter credit unless anonymity is
+requested.
 
 ## Handling Sensitive Artifacts
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support Policy
+
+## Supported Versions
+
+Security fixes are handled on the default branch and the latest tagged release
+line.
+
+Older tagged releases are generally superseded by the latest release. If an older
+release has a significant security impact and users cannot reasonably upgrade,
+the maintainer may publish a backport or mitigation note.
+
+## Upgrade Path
+
+Users should upgrade to the newest tagged release unless release notes describe a
+reason not to.
+
+For ABI-breaking releases:
+
+- the major version changes
+- release notes describe the compatibility impact
+- public headers and README API notes describe the new behavior
+- older tags remain available in Git
+
+## Getting Support
+
+- Defects and enhancement requests: open a GitHub issue.
+- Usage questions: use GitHub Discussions or an issue when discussion needs to
+  be tracked.
+- Security vulnerabilities: use the private process in `SECURITY.md`.
+
+## Security Update Expectations
+
+Confirmed vulnerabilities are fixed on the default branch first. The release
+notes or advisory will identify affected versions, available fixed versions, and
+known mitigations when practical.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,90 @@
+# Architecture
+
+mbelib-neo is a C library for IMBE/AMBE vocoder primitives. It is organized so
+public consumers use installed headers while codec internals remain private to
+the library.
+
+## Main Actors
+
+- Library consumer: application code that links `mbe_neo::mbe_shared`,
+  `mbe_neo::mbe_static`, or `libmbe-neo` through pkg-config.
+- Public API: declarations under `include/mbelib-neo/`.
+- Codec implementation: project-owned C sources under `src/`.
+- Vendored FFT implementation: PFFFT/FFTPACK sources under
+  `src/external/pffft/`.
+- Build and packaging system: CMake, CMake presets, install rules, CMake package
+  export, and pkg-config metadata.
+- Test and validation system: CTest executables under `tests/`, fuzz targets
+  under `fuzz/`, and CI workflows under `.github/workflows/`.
+
+## Source Layout
+
+- `include/mbelib-neo/`: installed public headers.
+- `src/core/`: shared synthesis, parameter, adaptive, and unvoiced FFT logic.
+- `src/ecc/`: error-correction helpers and constants.
+- `src/ambe/`: AMBE frame and data processing.
+- `src/imbe/`: IMBE frame and data processing.
+- `src/internal/`: private headers shared by implementation units.
+- `src/external/pffft/`: vendored third-party FFT sources.
+- `tests/`: automated unit and regression tests.
+- `examples/`: small consumer examples.
+- `bench/`: optional local micro-benchmarks.
+- `tools/`: local and CI-aligned quality scripts.
+
+## Public Interface
+
+The supported external software interface is the C API declared in
+`include/mbelib-neo/mbelib.h`, plus the generated version header
+`include/mbelib-neo/version.h` after configure/install.
+
+Consumers normally use:
+
+- `#include <mbelib-neo/mbelib.h>`
+- CMake target `mbe_neo::mbe_shared` or `mbe_neo::mbe_static`
+- pkg-config package `libmbe-neo`
+
+The library writes 8 kHz audio frames and keeps stream state in caller-provided
+`mbe_parms` objects. Processing APIs are reentrant when each stream has its own
+state.
+
+## Data Flow
+
+1. The caller provides hard-decision frames, soft-decision frames, or unpacked
+   parameter bits.
+2. Codec-specific decode logic validates frame layout, applies error correction
+   where applicable, and produces parameter bits or process status.
+3. Synthesis logic updates caller-owned stream state and emits float or int16
+   PCM samples.
+4. Optional status helpers format process results for diagnostics.
+
+## Trust Boundaries
+
+Frame and data buffers supplied by callers are untrusted input. Public functions
+must validate assumptions about dimensions, pointers, and bounded writes before
+using those buffers.
+
+Build scripts, CI workflow inputs, release credentials, and publication keys are
+separate trust boundaries. CI workflows use least-privilege permissions and
+dedicated analysis jobs to reduce the chance that untrusted changes can reach
+release credentials.
+
+## Build Architecture
+
+CMake builds shared and static libraries from explicit source lists. The project
+does not use source globbing for library sources, which keeps build membership
+reviewable.
+
+Install rules export:
+
+- library artifacts
+- public headers
+- generated version header
+- CMake package metadata
+- pkg-config metadata
+- license files
+
+## Dependency Architecture
+
+The main compiled third-party code is vendored PFFFT/FFTPACK. CI and analysis
+tools are managed through pinned workflow actions, hashed Python requirement
+files, and documented supply-chain guardrails.

--- a/docs/build-installation.md
+++ b/docs/build-installation.md
@@ -1,0 +1,92 @@
+# Build and Installation Policy
+
+mbelib-neo uses CMake as its primary build and installation system.
+
+## Standard Build Variables
+
+CMake honors standard compiler and linker selection mechanisms. Users may pass
+toolchain choices through environment variables or CMake cache variables,
+including:
+
+- `CC`
+- `CFLAGS`
+- `LDFLAGS`
+- `CMAKE_C_COMPILER`
+- `CMAKE_C_FLAGS`
+- `CMAKE_EXE_LINKER_FLAGS`
+- `CMAKE_SHARED_LINKER_FLAGS`
+
+The project may add warning, sanitizer, SIMD, LTO, or platform flags based on
+explicit CMake options, but should not discard user-supplied compiler or linker
+settings.
+
+## Debug Information
+
+The install rules do not strip binaries. If users request debug information
+through their compiler flags or build type, the build and installation process
+should preserve it.
+
+## Non-Recursive Build Structure
+
+The project uses one top-level CMake build graph with explicit source lists. It
+does not rely on recursive make invocations to build cross-dependent
+subdirectories.
+
+## Repeatable Builds
+
+To repeat a build from the same source tree, toolchain, options, and environment:
+
+```sh
+rm -rf build/repeatable
+cmake -S . -B build/repeatable -DCMAKE_BUILD_TYPE=Release
+cmake --build build/repeatable -j
+ctest --test-dir build/repeatable --output-on-failure
+```
+
+For release packages, use the tagged release workflow or reproduce its documented
+steps from `.github/workflows/ci.yml`.
+
+Known limits:
+
+- Floating-point optimization and SIMD choices can affect generated code and
+  output across architectures.
+- Binary identity across different compilers, operating systems, or CMake
+  generators is not guaranteed.
+- Release artifacts should be compared within the same source, toolchain,
+  platform, build options, and packaging environment.
+
+## Installation Conventions
+
+Install with CMake:
+
+```sh
+cmake --install build/dev-release --prefix /usr/local
+```
+
+On POSIX systems, staged packaging can use `DESTDIR`:
+
+```sh
+DESTDIR="$PWD/pkgroot" cmake --install build/dev-release --prefix /usr
+```
+
+Uninstall from the same build directory:
+
+```sh
+cmake --build build/dev-release --target uninstall
+```
+
+## Developer Setup
+
+For local development:
+
+```sh
+cmake --preset dev-debug
+cmake --build --preset dev-debug -j
+ctest --preset dev-debug --output-on-failure
+```
+
+Optional local hooks:
+
+```sh
+tools/install-git-hooks.sh
+```

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,60 @@
+# Dependency Management
+
+mbelib-neo keeps runtime dependencies small and reviewable.
+
+## Compiled Dependencies
+
+The project has one vendored compiled third-party component:
+
+- PFFFT/FFTPACK under `src/external/pffft/`
+
+The vendored code retains upstream license files and attribution. Updates should
+be small, traceable to upstream, and reviewed separately from unrelated changes.
+
+System dependencies used by consumers are:
+
+- C99 compiler
+- CMake 3.20 or newer
+- platform math library where required by the toolchain
+
+## Tooling Dependencies
+
+CI and local quality tools are tracked through:
+
+- `.github/requirements/*.in`
+- `.github/requirements/*.txt`
+- `.github/dependabot.yml`
+- `.github/workflows/*.yml`
+- `tools/*.sh`
+
+Hashed Python requirements are used where Python tooling is installed in CI.
+GitHub Actions are pinned to immutable commit SHAs by policy.
+
+## Monitoring
+
+The project monitors dependencies through:
+
+- Dependabot for GitHub Actions and Python requirements
+- GitHub dependency review on pull requests
+- OSV-Scanner through `tools/osv_scan.sh`
+- scheduled guardrail CI
+- OpenSSF Scorecard
+
+If a vulnerability is reported in a dependency:
+
+1. Determine whether the vulnerable code is present and reachable.
+2. Update or patch the dependency when exploitable.
+3. If not exploitable, document the reason in the narrowest available
+   suppression or advisory note.
+4. Add tests or checks when the issue could regress.
+
+## Update Policy
+
+Dependency updates should:
+
+- preserve license notices
+- avoid unrelated refactors
+- update documentation when dependency behavior or requirements change
+- run focused codec tests and `tools/osv_scan.sh`
+- receive human review when they affect compiled code, workflows, packaging, or
+  release behavior

--- a/docs/issue-reporting.md
+++ b/docs/issue-reporting.md
@@ -1,0 +1,30 @@
+# Issue Reporting
+
+Use GitHub Issues for public defect reports and enhancement requests:
+
+https://github.com/arancormonk/mbelib-neo/issues
+
+Use GitHub Discussions for broader usage questions when an issue is not yet
+actionable:
+
+https://github.com/arancormonk/mbelib-neo/discussions
+
+## Defect Reports
+
+Include:
+
+- mbelib-neo version, tag, or commit
+- operating system and compiler
+- CMake preset or build command
+- minimal reproduction steps
+- expected behavior
+- actual behavior
+- logs, test output, or sample code when useful
+
+Do not attach private captures, credentials, keys, or machine-specific
+configuration. Redact or synthesize test data before sharing it publicly.
+
+## Security Reports
+
+Do not report suspected vulnerabilities through public issues. Use the private
+process in `SECURITY.md`.

--- a/docs/project-site-and-localization.md
+++ b/docs/project-site-and-localization.md
@@ -1,0 +1,45 @@
+# Project Site, Accessibility, and Localization
+
+## Project Sites
+
+The official project site, repository, issue tracker, discussions, and release
+downloads are hosted on GitHub:
+
+https://github.com/arancormonk/mbelib-neo
+
+The project does not operate a separate website, user database, or password
+store. Authentication for repository and discussion access is handled by GitHub.
+
+## Password Security
+
+mbelib-neo does not store passwords for external users. Project sites that allow
+login are GitHub-hosted and rely on GitHub's authentication and password storage
+controls.
+
+The library runtime also does not store user passwords, authentication tokens,
+or private cryptographic keys.
+
+## Accessibility
+
+Project documentation is maintained as Markdown text in the repository so it can
+be read through GitHub, cloned locally, rendered by common Markdown tools, or
+converted to other formats.
+
+When adding documentation:
+
+- use descriptive headings
+- keep tables simple
+- avoid conveying important information by color alone
+- provide text alternatives for meaningful images if images are added
+- keep generated documentation navigable through headings and link text
+
+mbelib-neo is a C library and does not provide a graphical user interface.
+
+## Internationalization
+
+The library does not generate end-user prose, sort human-language text, process
+locale-sensitive text, or provide a graphical interface. Runtime output is
+limited to version/status strings and caller-controlled audio buffers.
+
+For that reason, software internationalization is currently not applicable to the
+library runtime. Documentation and issue discussion are maintained in English.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,84 @@
+# Release Verification
+
+Official releases are published through GitHub Releases:
+
+https://github.com/arancormonk/mbelib-neo/releases
+
+## Release Identifiers
+
+Release tags use the form `vX.Y.Z`. The tag must match the project version
+declared by CMake, or the release workflow fails before packaging.
+
+## Release Signing
+
+Release tags are signed with the maintainer release key. Obtain the maintainer's
+public keys from GitHub:
+
+```sh
+curl -fsSL https://github.com/arancormonk.gpg | gpg --import
+```
+
+Verify a release tag:
+
+```sh
+git fetch --tags https://github.com/arancormonk/mbelib-neo.git
+git tag -v v1.2.7
+```
+
+The expected release-signing key fingerprint for v1.2.7 is:
+
+```text
+5FAF 0C47 C8E1 F95D 33CD 83B1 E42E 43AD D853 F280
+```
+
+The repository also stores the original upstream mbelib author public key for
+historical attribution:
+
+```text
+mbelib_Author.pgp
+```
+
+That attribution key is:
+
+```text
+9E7A 5527 9CDC EBF7 BF1B D772 4F98 E863 EA5E FE2C
+```
+
+Do not confuse the upstream attribution key with the current release-signing key
+unless release notes explicitly say otherwise.
+
+## Asset Integrity
+
+Release assets are distributed over GitHub HTTPS. Each release includes
+`SHA256SUMS.txt` with hashes for packaged assets. New releases should also
+include `SHA256SUMS.txt.asc`, a detached signature over the checksum file.
+
+Download the release assets and checksum file from the release page, then verify
+the checksum file signature when `SHA256SUMS.txt.asc` is present:
+
+```sh
+gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
+```
+
+Then run:
+
+```sh
+sha256sum -c SHA256SUMS.txt
+```
+
+On macOS, use:
+
+```sh
+shasum -a 256 -c SHA256SUMS.txt
+```
+
+## Expected Release Author
+
+The expected release author is the project maintainer, `arancormonk`, using the
+public release-signing key documented above.
+
+## Release Review
+
+Before publication, release packaging must pass the required CI checks for the
+tag, including build, test, static-analysis, sanitizer, install/consume, and
+release validation jobs.

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -1,0 +1,154 @@
+# Security Requirements and Assurance
+
+mbelib-neo is a native C library. Its main security goal is to process
+potentially malformed codec frames without memory corruption, credential
+exposure, or unexpected process execution.
+
+## What Users Can Expect
+
+- Public APIs should not read or write outside documented caller-provided
+  buffers.
+- Processing functions should be reentrant when each stream uses separate
+  `mbe_parms` state.
+- The library should not execute shells, spawn processes, open network
+  connections, or access credentials during normal audio processing.
+- The library should not store authentication credentials or private keys.
+- The library should not implement network protocols or TLS.
+- Build and release workflows should use least-privilege permissions and avoid
+  exposing release credentials to pull-request code.
+- Security vulnerabilities should be handled through the private reporting
+  process in `SECURITY.md`.
+
+## What Users Should Not Expect
+
+- mbelib-neo does not provide patent licensing advice or patent clearance.
+- mbelib-neo is not a sandbox. Applications that process untrusted captures
+  should still use process isolation, privilege separation, and normal media
+  hardening practices.
+- Floating-point synthesis output is not guaranteed to be bit-identical across
+  all compiler, architecture, SIMD, and optimization combinations.
+- The library does not authenticate frame contents or determine whether an
+  upstream radio/capture source is trustworthy.
+
+## Threat Model
+
+Relevant threats include:
+
+- malformed frame data triggering buffer overflows or undefined behavior
+- crafted inputs driving excessive CPU work or unstable state transitions
+- mistakes in SIMD or architecture-specific code paths
+- accidental release of generated binaries, private captures, credentials, or
+  signing material
+- compromised CI/CD dependencies or workflow changes
+- vulnerabilities in vendored third-party code
+
+Out-of-scope threats include:
+
+- physical radio-layer attacks outside the library process
+- patent enforcement or licensing disputes
+- malicious applications intentionally misusing the library API
+- compromise of GitHub or package-hosting infrastructure outside the project's
+  control
+
+## Trust Boundaries
+
+- Caller-provided frame, data, state, and output buffers are untrusted until
+  checked by the API implementation.
+- Vendored code under `src/external/` is treated as external code and reviewed
+  separately from project-owned sources.
+- CI workflow files are security-sensitive because they control analyzer,
+  packaging, and release behavior.
+- Release signing keys, GitHub Actions secrets, and AUR credentials are
+  sensitive resources and must not be exposed to untrusted pull-request code.
+
+## Secure Design Controls
+
+The project applies the following controls:
+
+- explicit CMake source lists instead of broad source globbing
+- public API declarations separated from private implementation headers
+- test coverage for API helpers, ECC behavior, frame-state determinism, golden
+  PCM regression behavior, parameter behavior, float conversion parity, and SIMD
+  architecture detection
+- sanitizer CI for AddressSanitizer and UndefinedBehaviorSanitizer
+- ClusterFuzzLite PR fuzzing with AddressSanitizer for frame-processing paths
+- static analysis through CodeQL, Semgrep, clang-tidy, cppcheck, scan-build,
+  GCC `-fanalyzer`, and include-what-you-use
+- Gitleaks and GitHub secret scanning for credential leakage
+- OSV-Scanner and dependency review for dependency vulnerabilities
+- pinned GitHub Actions and zizmor workflow security checks
+- branch protection requiring status checks before merge
+
+## Assurance Case
+
+Claim: mbelib-neo's documented security requirements are met for the intended
+library use case when users build a supported release and call the public API as
+documented.
+
+Argument:
+
+- The main attacker-controlled boundary is caller-provided frame/data input.
+  Public API documentation and tests focus on bounded frame layouts, caller-owned
+  state, and bounded output behavior.
+- Common C implementation weaknesses are countered with compiler warnings,
+  sanitizer testing, static analysis, fuzzing, focused regression tests, and code
+  review.
+- CI/CD and release trust boundaries are controlled with branch protection,
+  pinned actions, least-privilege workflow permissions, secret scanning, OSV
+  scanning, dependency review, and workflow security linting.
+- The project does not implement network services, TLS, password storage, or
+  credential management, reducing the applicable attack surface for runtime
+  cryptography and authentication failures.
+
+Residual risk:
+
+- As a C library, memory-safety bugs remain possible and should be reported
+  privately.
+- Applications processing hostile captures should still use normal process
+  isolation and privilege reduction.
+- Vendored third-party code can contain defects and must be monitored and
+  updated when applicable vulnerabilities are found.
+
+## Hardening
+
+The project supports and exercises hardening through:
+
+- warning-enabled builds by default
+- optional warnings-as-errors
+- AddressSanitizer and UndefinedBehaviorSanitizer presets
+- CI sanitizer jobs
+- CI static-analysis jobs
+- release builds with controlled CMake options
+- no runtime shell execution from project-owned C code without explicit review
+
+## Input Validation Requirements
+
+Public entry points must validate API assumptions before use. In particular:
+
+- pointer parameters that are required for output or mutable state must be valid
+- fixed-size frame and data layouts must be respected
+- status strings must be bounded by caller-provided buffer size where the API
+  accepts a size-aware interface
+- new APIs should prefer const input and explicit output sizes
+- untrusted CI metadata must be passed through environment variables or action
+  inputs, not directly interpolated into shell scripts
+
+## Cryptography and Credentials
+
+The library does not implement cryptographic protocols, password storage, TLS,
+or credential management. Criteria about cryptographic algorithm agility,
+credential agility, TLS certificate verification, and network protocol security
+are not applicable to the library runtime.
+
+Project release and repository operations do use cryptographic mechanisms:
+
+- signed Git tags for releases
+- GitHub HTTPS for repository and release distribution
+- SHA256 release checksums
+- optional verification instructions in `docs/release-verification.md`
+
+## Vulnerability Handling
+
+Vulnerability reports are handled through `SECURITY.md`. Confirmed
+vulnerabilities should result in a fix, release note or advisory, affected
+version information, and reporter credit unless anonymity is requested.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,78 @@
+# Testing Policy
+
+mbelib-neo uses automated tests, static analysis, sanitizers, and fuzzing to
+reduce regression and security risk.
+
+## Test Suites
+
+The CTest suite includes:
+
+- API/version/result helper checks
+- ECC tests for hard and soft Golay/Hamming paths
+- noise determinism and frame-state determinism checks
+- parameter and synthesis behavior checks
+- float-to-int16 conversion parity checks
+- golden PCM hash regression checks
+- SIMD architecture detection checks
+
+Run the default test suite with:
+
+```sh
+cmake --preset dev-debug
+cmake --build --preset dev-debug -j
+ctest --preset dev-debug --output-on-failure
+```
+
+## Continuous Integration
+
+GitHub Actions runs tests and quality checks on pull requests and pushes to the
+primary branch. Required checks include cross-platform builds, sanitizer tests,
+static analysis, workflow linting, dependency review, secret scanning, OSV
+scanning, and install/consume checks.
+
+## Regression Test Requirement
+
+At least 50% of bugs fixed in the last six months should include regression
+tests. A pull request that fixes a bug should add a regression test unless:
+
+- the behavior cannot be reproduced reliably in automation
+- the fix is entirely documentation or packaging metadata
+- a better guardrail exists, such as a static-analysis rule or workflow check
+
+When no regression test is added for a bug fix, the pull request must explain
+why.
+
+## Major Functionality Test Requirement
+
+Major new functionality must add or update automated tests. Major functionality
+includes:
+
+- public API changes
+- codec or DSP behavior changes
+- external input handling changes
+- dependency changes that affect compiled code
+- security-sensitive workflow or release changes
+- installation and packaging behavior changes
+
+## Coverage Target
+
+The project target is at least 80% statement coverage for project-owned source
+files when measured with a FLOSS C coverage tool. Vendored code under
+`src/external/` is excluded from project-owned coverage accounting.
+
+Coverage evidence should be generated from an instrumented Debug build and
+recorded in a pull request, issue, or CI artifact before claiming coverage-based
+badge criteria.
+
+## Dynamic Analysis
+
+For memory-safety-sensitive C changes, run sanitizer tests:
+
+```sh
+cmake --preset asan-ubsan-debug
+cmake --build --preset asan-ubsan-debug -j
+ctest --preset asan-ubsan-debug --output-on-failure
+```
+
+Frame-processing paths are also covered by ClusterFuzzLite PR fuzzing with
+AddressSanitizer.

--- a/tests/test_frame_paths.c
+++ b/tests/test_frame_paths.c
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief API-level coverage for complete AMBE/IMBE frame processing paths.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+
+#include "mbelib-neo/mbelib.h"
+
+static void
+assert_float_pcm_sane(const float* pcm) {
+    for (int i = 0; i < 160; ++i) {
+        assert(isfinite(pcm[i]));
+        assert(pcm[i] > -20000.0f);
+        assert(pcm[i] < 20000.0f);
+    }
+}
+
+static void
+assert_status_terminated(const char* status, size_t size) {
+    int terminated = 0;
+    for (size_t i = 0; i < size; ++i) {
+        if (status[i] == '\0') {
+            terminated = 1;
+            break;
+        }
+    }
+    assert(terminated);
+}
+
+static void
+assert_result_total(const mbe_process_result* result, int ret) {
+    assert(ret == result->total_errors);
+    assert(result->total_errors == result->c0_errors + result->protected_errors);
+}
+
+static void
+init_params(mbe_parms* cur, mbe_parms* prev, mbe_parms* enh) {
+    mbe_initMbeParms(cur, prev, enh);
+    mbe_setThreadRngSeed(0x12345678u);
+}
+
+static void
+copy_bits(const char* src, char* dst, size_t count) {
+    memcpy(dst, src, count);
+}
+
+static void
+soft_from_bits(const char* hard, mbe_soft_bit* soft, size_t count) {
+    mbe_softBitsFromHard(hard, soft, count, 255u);
+}
+
+static void
+test_ambe2400_frame_paths(void) {
+    char frame[4][24] = {{0}};
+    char mutable_frame[4][24];
+    char hard_d[49] = {0};
+    char soft_d[49] = {0};
+    mbe_soft_bit soft_frame[4][24];
+    mbe_process_result hard_result;
+    mbe_process_result soft_result;
+    float out_f[160];
+    short out_s[160];
+    char status[256];
+    int errs = 0;
+    int errs2 = 0;
+    mbe_parms cur, prev, enh;
+
+    frame[0][0] = 1;
+    frame[1][7] = 1;
+    frame[2][3] = 1;
+    frame[3][11] = 1;
+    const char (*const_frame)[24] = (const char (*)[24])frame;
+    soft_from_bits(&frame[0][0], &soft_frame[0][0], (size_t)4 * 24u);
+    const mbe_soft_bit(*const_soft_frame)[24] = (const mbe_soft_bit(*)[24])soft_frame;
+
+    int hard_ret = mbe_decodeAmbe3600x2400Frame(const_frame, hard_d, &hard_result);
+    int soft_ret = mbe_decodeAmbe3600x2400SoftFrame(const_soft_frame, soft_d, &soft_result);
+    assert_result_total(&hard_result, hard_ret);
+    assert_result_total(&soft_result, soft_ret);
+    assert((hard_result.flags & MBE_PROCESS_FLAG_C0_VALID) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_C0_VALID) != 0u);
+
+    init_params(&cur, &prev, &enh);
+    memset(status, 0, sizeof(status));
+    mbe_processAmbe2400Dataf(out_f, &hard_result.c0_errors, &hard_result.total_errors, status, hard_d, &cur, &prev,
+                             &enh, 8);
+    assert_float_pcm_sane(out_f);
+    assert_status_terminated(status, sizeof(status));
+
+    init_params(&cur, &prev, &enh);
+    memset(status, 0, sizeof(status));
+    mbe_processAmbe2400Data(out_s, &hard_result.c0_errors, &hard_result.total_errors, status, hard_d, &cur, &prev, &enh,
+                            8);
+    assert_status_terminated(status, sizeof(status));
+
+    init_params(&cur, &prev, &enh);
+    mbe_process_result data_result = hard_result;
+    int ret = mbe_processAmbe2400DatafV2(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    assert_result_total(&data_result, ret);
+    assert_float_pcm_sane(out_f);
+
+    init_params(&cur, &prev, &enh);
+    data_result = hard_result;
+    ret = mbe_processAmbe2400DataV2(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    assert_result_total(&data_result, ret);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processAmbe3600x2400Framef(out_f, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_float_pcm_sane(out_f);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processAmbe3600x2400Frame(out_s, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    ret = mbe_processAmbe3600x2400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert_float_pcm_sane(out_f);
+
+    init_params(&cur, &prev, &enh);
+    ret = mbe_processAmbe3600x2400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+}
+
+static void
+test_imbe7200_frame_paths(void) {
+    char frame[8][23] = {{0}};
+    char mutable_frame[8][23];
+    char hard_d[88] = {0};
+    char soft_d[88] = {0};
+    mbe_soft_bit soft_frame[8][23];
+    mbe_process_result hard_result;
+    mbe_process_result soft_result;
+    float out_f[160];
+    short out_s[160];
+    char status[256];
+    int errs = 0;
+    int errs2 = 0;
+    mbe_parms cur, prev, enh;
+
+    frame[0][22] = 1;
+    frame[2][5] = 1;
+    frame[5][9] = 1;
+    frame[7][2] = 1;
+    const char (*const_frame)[23] = (const char (*)[23])frame;
+    soft_from_bits(&frame[0][0], &soft_frame[0][0], (size_t)8 * 23u);
+    const mbe_soft_bit(*const_soft_frame)[23] = (const mbe_soft_bit(*)[23])soft_frame;
+
+    int hard_ret = mbe_decodeImbe7200x4400Frame(const_frame, hard_d, &hard_result);
+    int soft_ret = mbe_decodeImbe7200x4400SoftFrame(const_soft_frame, soft_d, &soft_result);
+    assert_result_total(&hard_result, hard_ret);
+    assert_result_total(&soft_result, soft_ret);
+    assert((hard_result.flags & MBE_PROCESS_FLAG_C0_VALID) != 0u);
+    assert((hard_result.flags & MBE_PROCESS_FLAG_C4_VALID) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_C4_VALID) != 0u);
+
+    init_params(&cur, &prev, &enh);
+    memset(status, 0, sizeof(status));
+    mbe_processImbe4400Dataf(out_f, &hard_result.c0_errors, &hard_result.total_errors, status, hard_d, &cur, &prev,
+                             &enh, 8);
+    assert_float_pcm_sane(out_f);
+    assert_status_terminated(status, sizeof(status));
+
+    init_params(&cur, &prev, &enh);
+    memset(status, 0, sizeof(status));
+    mbe_processImbe4400Data(out_s, &hard_result.c0_errors, &hard_result.total_errors, status, hard_d, &cur, &prev, &enh,
+                            8);
+    assert_status_terminated(status, sizeof(status));
+
+    init_params(&cur, &prev, &enh);
+    mbe_process_result data_result = hard_result;
+    int ret = mbe_processImbe4400DatafV2(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    assert_result_total(&data_result, ret);
+    assert_float_pcm_sane(out_f);
+
+    init_params(&cur, &prev, &enh);
+    data_result = hard_result;
+    ret = mbe_processImbe4400DataV2(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    assert_result_total(&data_result, ret);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processImbe7200x4400Framef(out_f, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_float_pcm_sane(out_f);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processImbe7200x4400Frame(out_s, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    ret = mbe_processImbe7200x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert_float_pcm_sane(out_f);
+
+    init_params(&cur, &prev, &enh);
+    ret = mbe_processImbe7200x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+}
+
+static void
+test_imbe7100_frame_paths(void) {
+    char frame[7][24] = {{0}};
+    char mutable_frame[7][24];
+    char hard_d[88] = {0};
+    char soft_d[88] = {0};
+    mbe_soft_bit soft_frame[7][24];
+    mbe_process_result hard_result;
+    mbe_process_result soft_result;
+    float out_f[160];
+    short out_s[160];
+    char status[256];
+    int errs = 0;
+    int errs2 = 0;
+    mbe_parms cur, prev, enh;
+
+    frame[0][18] = 1;
+    frame[1][4] = 1;
+    frame[4][6] = 1;
+    frame[6][2] = 1;
+    const char (*const_frame)[24] = (const char (*)[24])frame;
+    soft_from_bits(&frame[0][0], &soft_frame[0][0], (size_t)7 * 24u);
+    const mbe_soft_bit(*const_soft_frame)[24] = (const mbe_soft_bit(*)[24])soft_frame;
+
+    int hard_ret = mbe_decodeImbe7100x4400Frame(const_frame, hard_d, &hard_result);
+    int soft_ret = mbe_decodeImbe7100x4400SoftFrame(const_soft_frame, soft_d, &soft_result);
+    assert_result_total(&hard_result, hard_ret);
+    assert_result_total(&soft_result, soft_ret);
+    assert((hard_result.flags & MBE_PROCESS_FLAG_C0_VALID) != 0u);
+    assert((hard_result.flags & MBE_PROCESS_FLAG_C4_VALID) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_C4_VALID) != 0u);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processImbe7100x4400Framef(out_f, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_float_pcm_sane(out_f);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    copy_bits(&frame[0][0], &mutable_frame[0][0], sizeof(frame));
+    memset(status, 0, sizeof(status));
+    mbe_processImbe7100x4400Frame(out_s, &errs, &errs2, status, mutable_frame, hard_d, &cur, &prev, &enh, 8);
+    assert_status_terminated(status, sizeof(status));
+    assert(errs2 >= errs);
+
+    init_params(&cur, &prev, &enh);
+    int ret = mbe_processImbe7100x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+    assert_float_pcm_sane(out_f);
+
+    init_params(&cur, &prev, &enh);
+    ret = mbe_processImbe7100x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    assert_result_total(&soft_result, ret);
+    assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
+}
+
+int
+main(void) {
+    test_ambe2400_frame_paths();
+    test_imbe7200_frame_paths();
+    test_imbe7100_frame_paths();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds the documentation, policy, and coverage evidence needed to support an OpenSSF Silver application path:

- contribution process, DCO, review expectations, and test policy
- code of conduct, governance, roles, access continuity, and roadmap
- support, issue reporting, architecture, build/install, dependency, testing, security assurance, and release verification docs
- README links to the policy set and Best Practices badges
- security response process and reporter-credit expectations
- issue templates and DCO checklist entry
- frame-path tests that raise filtered source coverage above 80%

## Validation

- `git diff --check HEAD~1 HEAD`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- filtered `lcov` coverage: 84.3% lines, 85.2% functions
- pre-push hook passed clang-format, gersemi, clang-tidy strict, IWYU, GCC fanalyzer, Semgrep, and Lizard
- GitHub PR checks passed, including CI matrix, CodeQL, guardrails, scan-build, sanitizers, and ClusterFuzzLite PR fuzzing

## Notes

This PR documents the Silver evidence path and adds coverage evidence. The remaining Silver items that cannot be completed purely in the public repo are operational: complete the private access-continuity packet and publish release signatures with the correct signing key.
