### PR TITLE
ci: publish tagged release assets from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,3 +767,61 @@ jobs:
           name: release-package-${{ runner.os }}-${{ runner.arch }}
           path: ${{ steps.package_windows.outputs.archive_path }}
           retention-days: 7
+
+  publish-release:
+    name: publish release
+    needs: [validate-release-tag, package-release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'arancormonk/mbelib-neo'
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download release package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: release-package-*
+          path: dist
+          merge-multiple: true
+      - name: Verify release packages and generate checksums
+        shell: bash
+        env:
+          ARCHIVE_PREFIX: ${{ needs.validate-release-tag.outputs.archive_prefix }}
+        run: |
+          set -euo pipefail
+          mapfile -t packages < <(
+            find dist -maxdepth 1 -type f \
+              \( -name "${ARCHIVE_PREFIX}-*.tar.gz" -o -name "${ARCHIVE_PREFIX}-*.zip" \) |
+              sort
+          )
+          if [ "${#packages[@]}" -ne 3 ]; then
+            echo "Expected 3 release packages, found ${#packages[@]}." >&2
+            find dist -maxdepth 1 -type f -print >&2
+            exit 1
+          fi
+          for platform in linux macos windows; do
+            if ! printf '%s\n' "${packages[@]}" | grep -Fq "/${ARCHIVE_PREFIX}-${platform}-"; then
+              echo "Missing ${platform} release package." >&2
+              exit 1
+            fi
+          done
+          : > dist/SHA256SUMS.txt
+          for package in "${packages[@]}"; do
+            (
+              cd dist
+              sha256sum "$(basename "$package")"
+            ) >> dist/SHA256SUMS.txt
+          done
+          cat dist/SHA256SUMS.txt
+      - name: Upload release assets
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        with:
+          files: |
+            dist/${{ needs.validate-release-tag.outputs.archive_prefix }}-*.tar.gz
+            dist/${{ needs.validate-release-tag.outputs.archive_prefix }}-*.zip
+            dist/SHA256SUMS.txt
+          name: mbelib-neo ${{ needs.validate-release-tag.outputs.version }}
+          generate_release_notes: true
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cmake --build build/dev-release --target uninstall
 GitHub Actions builds release package artifacts when you push a tag matching `vX.Y.Z`.
 The tag must match the project version declared in `CMakeLists.txt`, or the release workflow fails before packaging.
 
-On a matching tag, CI rebuilds `dev-release`, reruns the release preset tests, and packages the installed library tree for Linux, macOS, and Windows. Release publication is a maintainer action after the package artifacts and checks have been reviewed.
+On a matching tag, CI rebuilds `dev-release`, reruns the release preset tests, packages the installed library tree for Linux, macOS, and Windows, and creates or overwrites the matching GitHub Release assets.
 Release verification instructions are in `docs/release-verification.md`.
 
 Typical release flow:

--- a/docs/openssf-baseline.md
+++ b/docs/openssf-baseline.md
@@ -24,8 +24,8 @@ This document records mbelib-neo's evidence for OpenSSF OSPS Baseline Level 1.
   scripts.
 - Pull request workflows use least-privilege `GITHUB_TOKEN` permissions. The
   default GitHub Actions workflow permission for the repository is read-only.
-  Privileged publication credentials are only used in upstream non-PR release or
-  package update paths.
+  Release publication elevates `contents: write` only in trusted upstream
+  version-tag paths and publishes with the workflow `GITHUB_TOKEN`.
 - Official project channels and distribution channels are GitHub HTTPS URLs.
 - The project prevents accidental credential storage through contributor policy,
   GitHub secret scanning, Gitleaks CI, and review of workflow and release

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -50,8 +50,9 @@ unless release notes explicitly say otherwise.
 ## Asset Integrity
 
 Release assets are distributed over GitHub HTTPS. Each release includes
-`SHA256SUMS.txt` with hashes for packaged assets. New releases should also
-include `SHA256SUMS.txt.asc`, a detached signature over the checksum file.
+`SHA256SUMS.txt` with hashes for packaged assets. The tag release workflow
+creates or overwrites GitHub Release assets with the workflow `GITHUB_TOKEN`
+after packaging succeeds.
 
 Download the release assets and checksum file from the release page, then verify
 the checksum file signature when `SHA256SUMS.txt.asc` is present:


### PR DESCRIPTION
## Summary

- add a tagged-release publish job that downloads package artifacts from the same workflow run
- verify Linux, macOS, and Windows release packages are present
- regenerate `SHA256SUMS.txt` and overwrite matching GitHub Release assets with `GITHUB_TOKEN`
- update release/security documentation for the automated tagged-release path

## Root Cause

Tagged builds produced release package artifacts, but publication remained manual, so rerun tag workflows could leave existing GitHub Release assets unchanged.

## Validation

- `actionlint`
- `git diff --check`
- `tools/zizmor.sh`
- pre-push hook: Semgrep strict, workflow lint, zizmor, lizard

Note: pre-push scan-build full rebuild was skipped by the hook default.