### PR TITLE
Document required repository guardrail check

### DIFF
--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -35,6 +35,12 @@ Run the smallest useful set before opening a PR, then broaden it when the change
 - Release hardening changes: `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release`.
 - Dependency input changes: `tools/osv_scan.sh`.
 
+## Required PR Status Checks
+
+Branch protection must require the repository guardrail job for pull requests.
+Keep `repository guardrails` required whenever new repository-level security
+guardrails are added.
+
 ## Project-Specific Guardrails
 
 The repository intentionally blocks or flags patterns that are easy to reintroduce during large edits:

--- a/docs/openssf-baseline.md
+++ b/docs/openssf-baseline.md
@@ -11,8 +11,8 @@ This document records mbelib-neo's evidence for OpenSSF OSPS Baseline Level 1.
   intentionally granted by the maintainer, and elevated access is not granted by
   default.
 - The primary branch is `main`. GitHub branch protection is required for `main`,
-  including required status checks before merge. Direct commits to `main` are
-  blocked by the protected branch workflow.
+  including required status checks and repository guardrails before merge. Direct
+  commits to `main` are blocked by the protected branch workflow.
 - Deleting the protected `main` branch is disabled in GitHub branch protection.
 
 ## Build, Release, and Secrets Controls

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -80,7 +80,8 @@ The project applies the following controls:
 - OSV-Scanner and dependency review for dependency vulnerabilities
 - pinned GitHub Actions, pinned CI source checkouts, and zizmor workflow
   security checks
-- branch protection requiring status checks before merge
+- branch protection requiring status checks before merge, including repository
+  guardrails
 
 ## Solo Maintainer Operating Mode
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,8 +27,8 @@ ctest --preset dev-debug --output-on-failure
 
 GitHub Actions runs tests and quality checks on pull requests and pushes to the
 primary branch. Required checks include cross-platform builds, sanitizer tests,
-static analysis, workflow linting, dependency review, secret scanning, OSV
-scanning, and install/consume checks.
+static analysis, repository security guardrails, workflow linting, dependency
+review, secret scanning, OSV scanning, and install/consume checks.
 
 ## Regression Test Requirement
 


### PR DESCRIPTION
## Summary

- Record that branch protection requires the `repository guardrails` status check.
- Update testing, security requirements, and OpenSSF evidence docs to reflect repository-level security guardrails as required PR checks.

## Validation

- `git diff --check`
- `tools/check_workflow_git_pins.sh` via pre-push
- pre-push hook on `docs/required-pr-guardrails`

## Repository Settings

- Added `repository guardrails` to the required status checks for `main` branch protection.