### PR TITLE
Harden release and codec input validation

### DIFF
--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -7,8 +7,9 @@ https://github.com/arancormonk/mbelib-neo/releases
 ## Release Identifiers
 
 Release tags use the form `vX.Y.Z`. The tag must match the project version
-declared by CMake and must be an annotated tag signed by the trusted mbelib-neo
-release key, or the release workflow fails before packaging.
+declared by CMake, must be an annotated tag signed by the trusted mbelib-neo
+release key, and must point at a commit already contained in `origin/main`, or
+the release workflow fails before packaging.
 
 ## Release Signing
 
@@ -26,7 +27,8 @@ git fetch --tags https://github.com/arancormonk/mbelib-neo.git
 git tag -v v1.2.7
 ```
 
-The expected release-signing key fingerprint for v1.2.7 is:
+The release workflow pins this exact primary key fingerprint before trusting the
+checked-in key file:
 
 ```text
 5FAF 0C47 C8E1 F95D 33CD 83B1 E42E 43AD D853 F280

--- a/include/mbelib-neo/mbelib.h
+++ b/include/mbelib-neo/mbelib.h
@@ -632,6 +632,9 @@ MBE_API void mbe_useLastMbeParms(mbe_parms* cur_mp, const mbe_parms* prev_mp);
 MBE_API void mbe_initMbeParms(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
  * @brief Apply spectral amplitude enhancement in-place.
+ *
+ * Invalid parameter state, including an out-of-range harmonic count `L`, is
+ * ignored.
  * @param cur_mp In/out parameter set to enhance.
  */
 MBE_API void mbe_spectralAmpEnhance(mbe_parms* cur_mp);
@@ -656,6 +659,9 @@ MBE_API void mbe_synthesizeSilencef(float* aout_buf);
 MBE_API void mbe_synthesizeSilence(short* aout_buf);
 /**
  * @brief Synthesize one speech frame into float PCM.
+ *
+ * If `cur_mp` or `prev_mp` has an out-of-range harmonic count `L`, the output
+ * buffer is filled with silence.
  * @param aout_buf Output buffer of 160 float samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
@@ -664,6 +670,9 @@ MBE_API void mbe_synthesizeSilence(short* aout_buf);
 MBE_API void mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality);
 /**
  * @brief Synthesize one speech frame into 16-bit PCM.
+ *
+ * If `cur_mp` or `prev_mp` has an out-of-range harmonic count `L`, the output
+ * buffer is filled with silence.
  * @param aout_buf Output buffer of 160 16-bit samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
@@ -675,8 +684,10 @@ MBE_API void mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms*
  *
  * Applies the same scaling used by the `short` entry points: a fixed gain of
  * `7.0` and soft clipping at 95% of int16 full-scale before converting to
- * `short`. This makes the output equivalent to calling the corresponding
- * `short` synthesis APIs with the same input state.
+ * `short`. Non-finite input samples are handled before conversion: NaN becomes
+ * zero and infinities clip to the corresponding bound. This makes the output
+ * equivalent to calling the corresponding `short` synthesis APIs with the same
+ * input state.
  * @param float_buf Input 160 float samples.
  * @param aout_buf  Output 160 16-bit samples.
  */
@@ -724,6 +735,9 @@ MBE_API void mbe_synthesizeComfortNoise(short* aout_buf);
 /**
  * @brief Apply adaptive smoothing to parameters based on error rates.
  *        Implements JMBE Algorithms #111-116.
+ *
+ * Invalid parameter state, including an out-of-range harmonic count `L` in
+ * either parameter set, is ignored.
  * @param cur_mp Current frame parameters (modified in-place).
  * @param prev_mp Previous frame parameters (for local energy).
  */

--- a/src/core/mbe_adaptive.c
+++ b/src/core/mbe_adaptive.c
@@ -11,6 +11,7 @@
 
 #include "mbe_adaptive.h"
 #include "mbe_compiler.h"
+#include "mbe_validation.h"
 #include "mbelib-neo/mbelib.h"
 
 /* Thread-local storage for comfort noise RNG to avoid cross-thread interference.
@@ -150,6 +151,9 @@ mbe_synthesizeComfortNoise(short* aout_buf) {
 static float
 mbe_current_frame_rm0(const mbe_parms* cur_mp) {
     float rm0 = 0.0f;
+    if (!cur_mp || !mbe_harmonic_count_is_valid(cur_mp->L)) {
+        return 0.0f;
+    }
     for (int l = 1; l <= cur_mp->L; l++) {
         rm0 += cur_mp->Ml[l] * cur_mp->Ml[l];
     }
@@ -253,7 +257,8 @@ mbe_applyAdaptiveSmoothingCore(mbe_parms* cur_mp, const mbe_parms* prev_mp, floa
 
 void
 mbe_applyAdaptiveSmoothingWithRm0(mbe_parms* cur_mp, const mbe_parms* prev_mp, float rm0) {
-    if (MBE_UNLIKELY(!cur_mp || !prev_mp)) {
+    if (MBE_UNLIKELY(!cur_mp || !prev_mp || !mbe_harmonic_count_is_valid(cur_mp->L)
+                     || !mbe_harmonic_count_is_valid(prev_mp->L))) {
         return;
     }
 
@@ -262,7 +267,8 @@ mbe_applyAdaptiveSmoothingWithRm0(mbe_parms* cur_mp, const mbe_parms* prev_mp, f
 
 void
 mbe_applyAdaptiveSmoothing(mbe_parms* cur_mp, const mbe_parms* prev_mp) {
-    if (MBE_UNLIKELY(!cur_mp || !prev_mp)) {
+    if (MBE_UNLIKELY(!cur_mp || !prev_mp || !mbe_harmonic_count_is_valid(cur_mp->L)
+                     || !mbe_harmonic_count_is_valid(prev_mp->L))) {
         return;
     }
 

--- a/src/core/mbe_unvoiced_fft.c
+++ b/src/core/mbe_unvoiced_fft.c
@@ -12,6 +12,7 @@
 
 #include "mbe_compiler.h"
 #include "mbe_unvoiced_fft.h"
+#include "mbe_validation.h"
 #include "mbelib-neo/mbelib.h"
 #include "pffft.h"
 
@@ -641,6 +642,10 @@ mbe_magnitude_squared_sum(const float* restrict fft, int start, int end) {
 
 static void
 mbe_calculate_unvoiced_band_edges(int* a_min, int* b_max, int L, float w0) {
+    if (MBE_UNLIKELY(!mbe_harmonic_count_is_valid(L))) {
+        return;
+    }
+
     const float multiplier = MBE_256_OVER_2PI * w0;
 
     for (int l = 1; l <= L; l++) {
@@ -659,6 +664,10 @@ static void
 mbe_apply_unvoiced_band_scaling(float* restrict dftBinScalor, const float* restrict Uw_fft,
                                 const mbe_parms* restrict cur_mp, const int* restrict a_min,
                                 const int* restrict b_max) {
+    if (MBE_UNLIKELY(!mbe_harmonic_count_is_valid(cur_mp->L))) {
+        return;
+    }
+
     for (int l = 1; l <= cur_mp->L; l++) {
         if (cur_mp->Vl[l] == 0) {
             int bin_count = b_max[l] - a_min[l];
@@ -706,7 +715,8 @@ void
 mbe_synthesizeUnvoicedFFTWithNoise(float* restrict output, mbe_parms* restrict cur_mp,
                                    const mbe_parms* restrict prev_mp, mbe_fft_plan* restrict plan,
                                    const float* restrict noise_buffer) {
-    if (MBE_UNLIKELY(!output || !cur_mp || !prev_mp || !plan || !noise_buffer)) {
+    if (MBE_UNLIKELY(!output || !cur_mp || !prev_mp || !plan || !noise_buffer || !mbe_harmonic_count_is_valid(cur_mp->L)
+                     || !mbe_harmonic_count_is_valid(prev_mp->L))) {
         return;
     }
 
@@ -753,7 +763,8 @@ mbe_synthesizeUnvoicedFFTWithNoise(float* restrict output, mbe_parms* restrict c
 void
 mbe_synthesizeUnvoicedFFT(float* restrict output, mbe_parms* restrict cur_mp, const mbe_parms* restrict prev_mp,
                           mbe_fft_plan* restrict plan) {
-    if (MBE_UNLIKELY(!output || !cur_mp || !prev_mp || !plan)) {
+    if (MBE_UNLIKELY(!output || !cur_mp || !prev_mp || !plan || !mbe_harmonic_count_is_valid(cur_mp->L)
+                     || !mbe_harmonic_count_is_valid(prev_mp->L))) {
         return;
     }
 

--- a/src/core/mbelib.c
+++ b/src/core/mbelib.c
@@ -43,6 +43,7 @@
 #include "mbe_result.h"
 #include "mbe_tone.h"
 #include "mbe_unvoiced_fft.h"
+#include "mbe_validation.h"
 #include "mbelib-neo/mbelib.h"
 #include "mbelib-neo/version.h"
 #include "mbelib_const.h"
@@ -641,6 +642,10 @@ mbe_spectralAmpEnhanceWithRm0(mbe_parms* cur_mp) {
     float Rm0, Rm1;
     float cos_tab[57];
 
+    if (MBE_UNLIKELY(!cur_mp || !mbe_harmonic_count_is_valid(cur_mp->L))) {
+        return 0.0f;
+    }
+
     mbe_precompute_harmonic_cosines(cos_tab, cur_mp->L, cur_mp->w0);
     mbe_accumulate_spectral_energy(cur_mp, cos_tab, &Rm0, &Rm1);
 
@@ -1027,6 +1032,15 @@ mbe_synthesizeSpeechCore(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp,
 
     const int N = 160;
 
+    if (MBE_UNLIKELY(!aout_buf)) {
+        return;
+    }
+    if (MBE_UNLIKELY(!cur_mp || !prev_mp || !mbe_harmonic_count_is_valid(cur_mp->L)
+                     || !mbe_harmonic_count_is_valid(prev_mp->L))) {
+        mbe_synthesizeSilencef(aout_buf);
+        return;
+    }
+
     /* Silence unused parameter warning - uvquality is kept for API compatibility */
     (void)uvquality;
 
@@ -1101,6 +1115,9 @@ void
 mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality) {
     float float_buf[160];
 
+    if (MBE_UNLIKELY(!aout_buf)) {
+        return;
+    }
     mbe_synthesizeSpeechf(float_buf, cur_mp, prev_mp, uvquality);
     mbe_floattoshort(float_buf, aout_buf);
 }
@@ -1119,26 +1136,60 @@ mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int
  * @param float_buf Input 160 float samples.
  * @param aout_buf  Output 160 int16 samples.
  */
-#if defined(MBELIB_ENABLE_SIMD)
-static void
-mbe_floattoshort_scalar(const float* restrict float_buf, short* restrict aout_buf) {
-    /* JMBE-compatible soft clipping at 95% of maximum amplitude */
+static inline float
+mbe_scaleAndClipFloatSampleForShort(float sample) {
     const float again = 7.0f;
     const float max_amplitude = 32767.0f * 0.95f; /* ~31128.65 */
+    uint32_t sample_bits;
+    memcpy(&sample_bits, &sample, sizeof(sample_bits));
+
+    const uint32_t abs_bits = sample_bits & 0x7FFFFFFFu;
+    if (abs_bits > 0x7F800000u) {
+        return 0.0f;
+    }
+    if (abs_bits == 0x7F800000u) {
+        return ((sample_bits & 0x80000000u) != 0u) ? -max_amplitude : max_amplitude;
+    }
+
+    float audio = again * sample;
+    if (audio > max_amplitude) {
+#ifdef MBE_DEBUG
+        fprintf(stderr, "audio clip: %f\n", audio);
+#endif
+        return max_amplitude;
+    }
+    if (audio < -max_amplitude) {
+#ifdef MBE_DEBUG
+        fprintf(stderr, "audio clip: %f\n", audio);
+#endif
+        return -max_amplitude;
+    }
+    return audio;
+}
+
+#if defined(MBELIB_ENABLE_SIMD)
+static inline int
+mbe_floatSampleIsNonFinite(float sample) {
+    uint32_t sample_bits;
+    memcpy(&sample_bits, &sample, sizeof(sample_bits));
+
+    return (sample_bits & 0x7FFFFFFFu) >= 0x7F800000u;
+}
+
+static int
+mbe_floatBufferHasNonFinite(const float* float_buf) {
     for (int i = 0; i < 160; i++) {
-        float audio = again * float_buf[i];
-        if (audio > max_amplitude) {
-#ifdef MBE_DEBUG
-            fprintf(stderr, "audio clip: %f\n", audio);
-#endif
-            audio = max_amplitude;
-        } else if (audio < -max_amplitude) {
-#ifdef MBE_DEBUG
-            fprintf(stderr, "audio clip: %f\n", audio);
-#endif
-            audio = -max_amplitude;
+        if (mbe_floatSampleIsNonFinite(float_buf[i])) {
+            return 1;
         }
-        aout_buf[i] = (short)(audio);
+    }
+    return 0;
+}
+
+static void
+mbe_floattoshort_scalar(const float* restrict float_buf, short* restrict aout_buf) {
+    for (int i = 0; i < 160; i++) {
+        aout_buf[i] = (short)mbe_scaleAndClipFloatSampleForShort(float_buf[i]);
     }
 }
 
@@ -1235,33 +1286,27 @@ mbe_init_runtime_dispatch(void) {
 
 void
 mbe_floattoshort(const float* restrict float_buf, short* restrict aout_buf) {
+    if (MBE_UNLIKELY(!float_buf || !aout_buf)) {
+        return;
+    }
+    if (MBE_UNLIKELY(mbe_floatBufferHasNonFinite(float_buf))) {
+        mbe_floattoshort_scalar(float_buf, aout_buf);
+        return;
+    }
     if (MBE_UNLIKELY(!mbe_floattoshort_impl)) {
         mbe_init_runtime_dispatch();
     }
     mbe_floattoshort_impl(float_buf, aout_buf);
 }
 
-#else /* MBELIB_ENABLE_SIMD not set: keep scalar implementation */
+#else  /* MBELIB_ENABLE_SIMD not set: keep scalar implementation */
 void
 mbe_floattoshort(const float* restrict float_buf, short* restrict aout_buf) {
-    /* JMBE-compatible soft clipping at 95% of maximum amplitude
-     * This provides headroom and prevents harsh clipping artifacts */
-    const float again = 7.0f;
-    const float max_amplitude = 32767.0f * 0.95f; /* ~31128.65 */
+    if (MBE_UNLIKELY(!float_buf || !aout_buf)) {
+        return;
+    }
     for (int i = 0; i < 160; i++) {
-        float audio = again * float_buf[i];
-        if (audio > max_amplitude) {
-#ifdef MBE_DEBUG
-            fprintf(stderr, "audio clip: %f\n", audio);
-#endif
-            audio = max_amplitude;
-        } else if (audio < -max_amplitude) {
-#ifdef MBE_DEBUG
-            fprintf(stderr, "audio clip: %f\n", audio);
-#endif
-            audio = -max_amplitude;
-        }
-        aout_buf[i] = (short)(audio);
+        aout_buf[i] = (short)mbe_scaleAndClipFloatSampleForShort(float_buf[i]);
     }
 }
 #endif /* MBELIB_ENABLE_SIMD */

--- a/src/internal/mbe_result.h
+++ b/src/internal/mbe_result.h
@@ -7,6 +7,7 @@
 #define MBELIB_NEO_INTERNAL_MBE_RESULT_H
 
 #include <stddef.h>
+#include "mbe_validation.h"
 #include "mbelib-neo/mbelib.h"
 
 #define MBE_RESULT_CONTEXT_FLAGS (MBE_PROCESS_FLAG_SOFT_INPUT | MBE_PROCESS_FLAG_C0_VALID | MBE_PROCESS_FLAG_C4_VALID)
@@ -38,24 +39,51 @@ mbe_validate_soft_bits(const mbe_soft_bit* bits, size_t count) {
 }
 
 static inline int
+mbe_result_validate_component_errors(const mbe_process_result* result, int* component_total) {
+    if (!mbe_error_count_is_valid(result->c0_errors) || !mbe_error_count_is_valid(result->protected_errors)
+        || !mbe_error_count_is_valid(result->c4_errors) || !mbe_error_count_is_valid(result->total_errors)) {
+        return MBE_STATUS_INVALID_ARGUMENT;
+    }
+    if (result->c0_errors > MBE_MAX_FRAME_BITS - result->protected_errors) {
+        return MBE_STATUS_INVALID_ARGUMENT;
+    }
+
+    *component_total = result->c0_errors + result->protected_errors;
+    if (!mbe_error_count_is_valid(*component_total)) {
+        return MBE_STATUS_INVALID_ARGUMENT;
+    }
+
+    return 0;
+}
+
+static inline int
+mbe_result_total_errors_are_consistent(const mbe_process_result* result, int total, int component_total) {
+    const int c0_valid = (result->flags & MBE_PROCESS_FLAG_C0_VALID) != 0u;
+    const int c4_valid = (result->flags & MBE_PROCESS_FLAG_C4_VALID) != 0u;
+
+    return (component_total == 0 || total >= component_total) && (!c0_valid || total >= result->c0_errors)
+           && (!c4_valid || total >= result->c4_errors);
+}
+
+static inline int
 mbe_result_resolve_total_errors(const mbe_process_result* result, int* total_errors) {
+    int component_total = 0;
     int total = 0;
 
     if (!total_errors) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    if (result) {
-        if (result->c0_errors < 0 || result->protected_errors < 0 || result->c4_errors < 0
-            || result->total_errors < 0) {
-            return MBE_STATUS_INVALID_ARGUMENT;
-        }
-        total = result->total_errors;
-        if (total == 0 && (result->c0_errors != 0 || result->protected_errors != 0)) {
-            total = result->c0_errors + result->protected_errors;
-        }
-        if (((result->flags & MBE_PROCESS_FLAG_C0_VALID) != 0u) && total < result->c0_errors) {
-            return MBE_STATUS_INVALID_ARGUMENT;
-        }
+    if (!result) {
+        *total_errors = 0;
+        return 0;
+    }
+    if (mbe_result_validate_component_errors(result, &component_total) < 0) {
+        return MBE_STATUS_INVALID_ARGUMENT;
+    }
+
+    total = (result->total_errors == 0 && component_total != 0) ? component_total : result->total_errors;
+    if (!mbe_result_total_errors_are_consistent(result, total, component_total)) {
+        return MBE_STATUS_INVALID_ARGUMENT;
     }
 
     *total_errors = total;

--- a/src/internal/mbe_validation.h
+++ b/src/internal/mbe_validation.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef MBELIB_NEO_INTERNAL_MBE_VALIDATION_H
+#define MBELIB_NEO_INTERNAL_MBE_VALIDATION_H
+
+#define MBE_MIN_HARMONIC_BANDS 1
+#define MBE_MAX_HARMONIC_BANDS 56
+#define MBE_MAX_FRAME_BITS     184
+
+static inline int
+mbe_harmonic_count_is_valid(int L) {
+    return L >= MBE_MIN_HARMONIC_BANDS && L <= MBE_MAX_HARMONIC_BANDS;
+}
+
+static inline int
+mbe_error_count_is_valid(int count) {
+    return count >= 0 && count <= MBE_MAX_FRAME_BITS;
+}
+
+#endif /* MBELIB_NEO_INTERNAL_MBE_VALIDATION_H */

--- a/tests/test_floattoshort_parity.c
+++ b/tests/test_floattoshort_parity.c
@@ -8,6 +8,7 @@
  * @brief Exact parity checks for mbe_floattoshort().
  */
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -21,6 +22,9 @@ reference_floattoshort(float sample) {
     const float again = 7.0f;
     const float max_amplitude = 32767.0f * 0.95f;
     float audio = again * sample;
+    if (audio != audio) {
+        audio = 0.0f;
+    }
     if (audio > max_amplitude) {
         audio = max_amplitude;
     } else if (audio < -max_amplitude) {
@@ -49,6 +53,9 @@ fill_test_input(float* input, uint32_t seed) {
     input[6] = -clip_point + (1.0f / 32768.0f);
     input[7] = 1.0f / 7.0f;
     input[8] = -1.0f / 7.0f;
+    input[9] = NAN;
+    input[10] = INFINITY;
+    input[11] = -INFINITY;
 }
 
 int

--- a/tests/test_input_validation.c
+++ b/tests/test_input_validation.c
@@ -9,6 +9,7 @@
  */
 
 #include <assert.h>
+#include <limits.h>
 #include <string.h>
 
 #include "mbelib-neo/mbelib.h"
@@ -20,6 +21,13 @@ init_params(mbe_parms* cur, mbe_parms* prev, mbe_parms* enh) {
 
 static void
 assert_float_buffer_unchanged(const float* out, float value) {
+    for (int i = 0; i < 160; ++i) {
+        assert(out[i] == value);
+    }
+}
+
+static void
+assert_short_buffer_unchanged(const short* out, short value) {
     for (int i = 0; i < 160; ++i) {
         assert(out[i] == value);
     }
@@ -76,18 +84,150 @@ test_invalid_parameter_bits_rejected_before_synthesis(void) {
     assert_float_buffer_unchanged(out, 123.0f);
 }
 
-static void
-test_invalid_result_context_rejected(void) {
+static int
+process_imbe4400_with_result_context(const mbe_process_result* context) {
     char params[88] = {0};
     float out[160] = {0};
-    mbe_process_result result;
+    mbe_process_result result = *context;
     mbe_parms cur = {0}, prev = {0}, enh = {0};
 
     init_params(&cur, &prev, &enh);
+
+    return mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8);
+}
+
+static void
+expect_invalid_result_context(mbe_process_result result) {
+    assert(process_imbe4400_with_result_context(&result) == MBE_STATUS_INVALID_ARGUMENT);
+}
+
+static void
+expect_valid_result_context(mbe_process_result result) {
+    assert(process_imbe4400_with_result_context(&result) >= 0);
+}
+
+static void
+test_invalid_result_context_rejected(void) {
+    mbe_process_result result;
+
     mbe_initProcessResult(&result);
     result.total_errors = -1;
+    expect_invalid_result_context(result);
 
-    assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8) == MBE_STATUS_INVALID_ARGUMENT);
+    mbe_initProcessResult(&result);
+    result.total_errors = 185;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.total_errors = INT_MAX;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.c0_errors = INT_MAX;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.protected_errors = 185;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.c4_errors = 185;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.c0_errors = 100;
+    result.protected_errors = 85;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.flags = MBE_PROCESS_FLAG_C0_VALID;
+    result.c0_errors = 7;
+    result.total_errors = 6;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.flags = MBE_PROCESS_FLAG_C4_VALID;
+    result.c4_errors = 7;
+    result.total_errors = 6;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.c0_errors = 100;
+    result.protected_errors = 84;
+    expect_valid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.total_errors = 184;
+    expect_valid_result_context(result);
+}
+
+static void
+test_invalid_harmonic_counts_rejected_by_raw_helpers(void) {
+    static const int invalid_l_values[] = {-1, 0, 57, 1000};
+
+    for (size_t i = 0; i < sizeof(invalid_l_values) / sizeof(invalid_l_values[0]); ++i) {
+        const int invalid_l = invalid_l_values[i];
+        float out[160];
+        short out_s[160];
+        mbe_parms cur = {0}, prev = {0}, enh = {0};
+
+        init_params(&cur, &prev, &enh);
+        for (int j = 0; j < 160; ++j) {
+            out[j] = 123.0f;
+        }
+        cur.L = invalid_l;
+        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        assert_float_buffer_unchanged(out, 0.0f);
+
+        init_params(&cur, &prev, &enh);
+        for (int j = 0; j < 160; ++j) {
+            out[j] = 123.0f;
+        }
+        prev.L = invalid_l;
+        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        assert_float_buffer_unchanged(out, 0.0f);
+
+        init_params(&cur, &prev, &enh);
+        for (int j = 0; j < 160; ++j) {
+            out_s[j] = 123;
+        }
+        cur.L = invalid_l;
+        mbe_synthesizeSpeech(out_s, &cur, &prev, 8);
+        assert_short_buffer_unchanged(out_s, 0);
+
+        init_params(&cur, &prev, &enh);
+        cur.L = invalid_l;
+        cur.Ml[1] = 3.0f;
+        cur.Ml[56] = 5.0f;
+        cur.gamma = 9.0f;
+        mbe_spectralAmpEnhance(&cur);
+        assert(cur.L == invalid_l);
+        assert(cur.Ml[1] == 3.0f);
+        assert(cur.Ml[56] == 5.0f);
+        assert(cur.gamma == 9.0f);
+
+        init_params(&cur, &prev, &enh);
+        cur.L = invalid_l;
+        cur.errorRate = 1.0f;
+        cur.errorCountTotal = 10;
+        cur.localEnergy = 123.0f;
+        cur.amplitudeThreshold = 321;
+        mbe_applyAdaptiveSmoothing(&cur, &prev);
+        assert(cur.L == invalid_l);
+        assert(cur.localEnergy == 123.0f);
+        assert(cur.amplitudeThreshold == 321);
+
+        init_params(&cur, &prev, &enh);
+        prev.L = invalid_l;
+        cur.errorRate = 1.0f;
+        cur.errorCountTotal = 10;
+        cur.localEnergy = 123.0f;
+        cur.amplitudeThreshold = 321;
+        mbe_applyAdaptiveSmoothing(&cur, &prev);
+        assert(prev.L == invalid_l);
+        assert(cur.localEnergy == 123.0f);
+        assert(cur.amplitudeThreshold == 321);
+    }
 }
 
 static void
@@ -120,6 +260,7 @@ main(void) {
     test_invalid_soft_frame_rejected_before_decode();
     test_invalid_parameter_bits_rejected_before_synthesis();
     test_invalid_result_context_rejected();
+    test_invalid_harmonic_counts_rejected_by_raw_helpers();
     test_low_level_public_bit_paths_validate();
     return 0;
 }

--- a/tools/ci_validate_release_tag.sh
+++ b/tools/ci_validate_release_tag.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+expected_release_signing_fingerprint="5FAF0C47C8E1F95D33CD83B1E42E43ADD853F280"
+protected_main_ref="refs/remotes/origin/main"
 
 project_version="$(
   sed -nE 's/^[[:space:]]*project\([[:space:]]*mbelib-neo[[:space:]]+VERSION[[:space:]]+([0-9]+[.][0-9]+[.][0-9]+).*$/\1/p' \
@@ -58,6 +60,25 @@ if ! git rev-parse -q --verify "refs/tags/${tag}^{tag}" > /dev/null; then
   exit 1
 fi
 
+if ! git fetch --force origin "+refs/heads/main:${protected_main_ref}" > /dev/null 2>&1; then
+  echo "Failed to fetch protected main branch from origin." >&2
+  exit 1
+fi
+
+if [[ "$(git rev-parse --is-shallow-repository 2> /dev/null || echo false)" == "true" ]]; then
+  if ! git fetch --force --unshallow origin "+refs/heads/main:${protected_main_ref}" > /dev/null 2>&1; then
+    echo "Failed to fetch enough history to validate ${tag} against origin/main." >&2
+    exit 1
+  fi
+fi
+
+tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}")"
+main_commit="$(git rev-parse "${protected_main_ref}^{commit}")"
+if ! git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
+  echo "Release tag ${tag} target ${tag_commit} is not contained in origin/main ${main_commit}." >&2
+  exit 1
+fi
+
 trusted_key="${repo_root}/release-keys/arancormonk-2026.pgp"
 if [[ ! -f "${trusted_key}" ]]; then
   echo "Trusted release key not found: ${trusted_key}" >&2
@@ -72,15 +93,18 @@ trap cleanup_gnupg_home EXIT
 chmod 700 "${gnupg_home}"
 
 GNUPGHOME="${gnupg_home}" gpg --batch --import "${trusted_key}" > /dev/null
-ownertrust="$(
+imported_primary_fingerprint="$(
   GNUPGHOME="${gnupg_home}" gpg --batch --with-colons --fingerprint --list-keys |
-    awk -F: '$1 == "pub" { trust_next_fpr = 1; next } trust_next_fpr && $1 == "fpr" { print $10 ":6:"; trust_next_fpr = 0 }'
+    awk -F: '$1 == "pub" { want_fpr = 1; next } want_fpr && $1 == "fpr" { print $10; want_fpr = 0 }'
 )"
-if [[ -z "${ownertrust}" ]]; then
-  echo "Trusted release key import did not produce any public key fingerprints." >&2
+if [[ "${imported_primary_fingerprint}" != "${expected_release_signing_fingerprint}" ]]; then
+  echo "Release key fingerprint mismatch." >&2
+  echo "Expected: ${expected_release_signing_fingerprint}" >&2
+  echo "Imported: ${imported_primary_fingerprint:-<none>}" >&2
   exit 1
 fi
-printf '%s\n' "${ownertrust}" | GNUPGHOME="${gnupg_home}" gpg --batch --import-ownertrust > /dev/null
+printf '%s:6:\n' "${expected_release_signing_fingerprint}" |
+  GNUPGHOME="${gnupg_home}" gpg --batch --import-ownertrust > /dev/null
 if ! GNUPGHOME="${gnupg_home}" git verify-tag "${tag}" > /dev/null; then
   echo "Release tag ${tag} is not signed by a trusted mbelib-neo release key." >&2
   exit 1


### PR DESCRIPTION
## Summary

- Pin the trusted release signing key fingerprint during release-tag validation and require release tags to point at commits contained in `origin/main`.
- Add shared internal bounds for harmonic counts and frame error counters, then reject malformed raw synthesis/enhancement state before fixed-size array access.
- Make caller-supplied result contexts reject oversized counters and inconsistent totals without signed overflow.
- Sanitize non-finite float samples before `short` conversion and cover scalar/SIMD parity with regression tests.
- Update release verification and public API docs for the tightened contracts.

## Validation

- `cmake --preset asan-ubsan-debug`
- `cmake --build --preset asan-ubsan-debug --parallel`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ctest --preset asan-ubsan-debug --output-on-failure`
- `cmake -S . -B build/simd-asan-ubsan-debug -DCMAKE_BUILD_TYPE=Debug -DMBELIB_ENABLE_ASAN=ON -DMBELIB_ENABLE_UBSAN=ON -DMBELIB_ENABLE_SIMD=ON -DMBELIB_BUILD_TESTS=ON`
- `cmake --build build/simd-asan-ubsan-debug --parallel`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ctest --test-dir build/simd-asan-ubsan-debug --output-on-failure`
- `tools/check_workflow_git_pins.sh`
- `tools/check_workflow_download_pins.sh`
- `tools/shell_lint.sh`
- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- `tools/semgrep.sh --strict`
- `tools/cmake_format_check.sh`
- `tools/lizard.sh`
- pre-push hook: clang-format, clang-tidy, cppcheck, IWYU, GCC fanalyzer, Semgrep, shell lint, Lizard
