### PR TITLE
Harden IMBE interpolation and helper validation

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address]
+        sanitizer: [address, undefined]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/include/mbelib-neo/mbelib.h
+++ b/include/mbelib-neo/mbelib.h
@@ -614,20 +614,20 @@ MBE_API void mbe_setThreadRngSeed(uint32_t seed);
 /**
  * @brief Copy MBE parameter set from one struct to another.
  * @param cur_mp Source parameters.
- * @param prev_mp Destination parameters.
+ * @param prev_mp Destination parameters. If either pointer is NULL, this is a no-op.
  */
 MBE_API void mbe_moveMbeParms(const mbe_parms* cur_mp, mbe_parms* prev_mp);
 /**
  * @brief Replace current parameters with the last known parameters.
  * @param cur_mp Destination parameters to fill.
- * @param prev_mp Source parameters from previous frame.
+ * @param prev_mp Source parameters from previous frame. If either pointer is NULL, this is a no-op.
  */
 MBE_API void mbe_useLastMbeParms(mbe_parms* cur_mp, const mbe_parms* prev_mp);
 /**
  * @brief Initialize parameter state for decoding and synthesis.
  * @param cur_mp Output: current parameter state.
  * @param prev_mp Output: previous parameter state (zeroed/reset).
- * @param prev_mp_enhanced Output: enhanced previous parameter state.
+ * @param prev_mp_enhanced Output: enhanced previous parameter state. If any output pointer is NULL, this is a no-op.
  */
 MBE_API void mbe_initMbeParms(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
@@ -642,14 +642,14 @@ MBE_API void mbe_spectralAmpEnhance(mbe_parms* cur_mp);
  * @brief Synthesize tone frame (AMBE tone indices) into float PCM.
  * @param aout_buf Output buffer of 160 float samples.
  * @param ambe_d   AMBE parameter bits (49).
- * @param cur_mp   Current parameter set (tone synthesis state).
+ * @param cur_mp   Current parameter set (tone synthesis state). NULL or invalid tone inputs synthesize silence.
  */
 MBE_API void mbe_synthesizeTonef(float* aout_buf, const char* ambe_d, mbe_parms* cur_mp);
 /**
  * @brief Synthesize tone for D-STAR style indices into float PCM.
  * @param aout_buf Output buffer of 160 float samples.
  * @param ambe_d   AMBE parameter bits (49).
- * @param cur_mp   Current parameter set.
+ * @param cur_mp   Current parameter set. NULL synthesizes silence.
  * @param ID1      Tone index selector.
  */
 MBE_API void mbe_synthesizeTonefdstar(float* aout_buf, const char* ambe_d, mbe_parms* cur_mp, int ID1);

--- a/src/core/mbelib.c
+++ b/src/core/mbelib.c
@@ -343,6 +343,9 @@ mbe_versionString(void) {
  */
 void
 mbe_moveMbeParms(const mbe_parms* cur_mp, mbe_parms* prev_mp) {
+    if (!cur_mp || !prev_mp) {
+        return;
+    }
     *prev_mp = *cur_mp;
 }
 
@@ -355,6 +358,9 @@ mbe_moveMbeParms(const mbe_parms* cur_mp, mbe_parms* prev_mp) {
  */
 void
 mbe_useLastMbeParms(mbe_parms* cur_mp, const mbe_parms* prev_mp) {
+    if (!cur_mp || !prev_mp) {
+        return;
+    }
     *cur_mp = *prev_mp;
 }
 
@@ -366,6 +372,10 @@ mbe_useLastMbeParms(mbe_parms* cur_mp, const mbe_parms* prev_mp) {
  */
 void
 mbe_initMbeParms(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
+
+    if (!cur_mp || !prev_mp || !prev_mp_enhanced) {
+        return;
+    }
 
     int l;
     prev_mp->swn = 0;
@@ -750,6 +760,11 @@ mbe_synthesizeTonef(float* aout_buf, const char* ambe_d, mbe_parms* cur_mp) {
 #else
     int i;
 
+    if (!cur_mp || mbe_validate_bits(ambe_d, 49u) < 0) {
+        mbe_synthesizeSilencef(aout_buf);
+        return;
+    }
+
     int u0, u1, u2, u3;
     u0 = u1 = u2 = u3 = 0;
 
@@ -815,6 +830,11 @@ mbe_synthesizeTonefdstar(float* aout_buf, const char* ambe_d, mbe_parms* cur_mp,
     int AD = 103; /* JMBE nominal D-STAR tone amplitude */
     float freq1 = 0, freq2 = 0;
     (void)ambe_d;
+
+    if (!cur_mp) {
+        mbe_synthesizeSilencef(aout_buf);
+        return;
+    }
 
     switch (ID1) {
         // single tones, set frequency

--- a/src/imbe/imbe7200x4400.c
+++ b/src/imbe/imbe7200x4400.c
@@ -24,6 +24,7 @@
 #include "mbe_adaptive.h"
 #include "mbe_compiler.h"
 #include "mbe_result.h"
+#include "mbe_validation.h"
 #include "mbelib-neo/mbelib.h"
 
 /**
@@ -311,22 +312,44 @@ imbe_spectral_rho(int L) {
     return 0.7f;
 }
 
+static int
+imbe_clamp_harmonic_count(int L) {
+    if (L < MBE_MIN_HARMONIC_BANDS) {
+        return MBE_MIN_HARMONIC_BANDS;
+    }
+    if (L > MBE_MAX_HARMONIC_BANDS) {
+        return MBE_MAX_HARMONIC_BANDS;
+    }
+    return L;
+}
+
 static void
 imbe_update_spectral_amplitudes(mbe_parms* cur_mp, mbe_parms* prev_mp, const float Tl[57], float rho) {
     int intkl[57];
     float flokl[57], deltal[57];
+    int cur_L = imbe_clamp_harmonic_count(cur_mp->L);
+    int prev_L = imbe_clamp_harmonic_count(prev_mp->L);
 
-    if (cur_mp->L > prev_mp->L) {
-        for (int l = prev_mp->L + 1; l <= cur_mp->L; l++) {
-            prev_mp->Ml[l] = prev_mp->Ml[prev_mp->L];
-            prev_mp->log2Ml[l] = prev_mp->log2Ml[prev_mp->L];
+    cur_mp->L = cur_L;
+
+    if (cur_L > prev_L) {
+        for (int l = prev_L + 1; l <= cur_L; l++) {
+            prev_mp->Ml[l] = prev_mp->Ml[prev_L];
+            prev_mp->log2Ml[l] = prev_mp->log2Ml[prev_L];
         }
     }
+    prev_mp->log2Ml[0] = prev_mp->log2Ml[1];
+    prev_mp->Ml[0] = prev_mp->Ml[1];
 
     float Sum77 = 0;
-    for (int l = 1; l <= cur_mp->L; l++) {
-        flokl[l] = ((float)prev_mp->L / (float)cur_mp->L) * (float)l;
+    for (int l = 1; l <= cur_L; l++) {
+        flokl[l] = ((float)prev_L / (float)cur_L) * (float)l;
         intkl[l] = (int)(flokl[l]);
+        if (intkl[l] < 0) {
+            intkl[l] = 0;
+        } else if (intkl[l] > MBE_MAX_HARMONIC_BANDS) {
+            intkl[l] = MBE_MAX_HARMONIC_BANDS;
+        }
 #ifdef IMBE_DEBUG
         fprintf(stderr, "flokl: %e, intkl: %i ", flokl[l], intkl[l]);
 #endif
@@ -334,18 +357,25 @@ imbe_update_spectral_amplitudes(mbe_parms* cur_mp, mbe_parms* prev_mp, const flo
 #ifdef IMBE_DEBUG
         fprintf(stderr, "deltal: %e ", deltal[l]);
 #endif
-        Sum77 = Sum77
-                + ((((float)1 - deltal[l]) * prev_mp->log2Ml[intkl[l]]) + (deltal[l] * prev_mp->log2Ml[intkl[l] + 1]));
+        int upper = intkl[l] + 1;
+        if (upper > MBE_MAX_HARMONIC_BANDS) {
+            upper = MBE_MAX_HARMONIC_BANDS;
+        }
+        Sum77 = Sum77 + ((((float)1 - deltal[l]) * prev_mp->log2Ml[intkl[l]]) + (deltal[l] * prev_mp->log2Ml[upper]));
     }
-    Sum77 = ((rho / (float)cur_mp->L) * Sum77);
+    Sum77 = ((rho / (float)cur_L) * Sum77);
 
 #ifdef IMBE_DEBUG
     fprintf(stderr, "Sum77: %e\n", Sum77);
 #endif
 
-    for (int l = 1; l <= cur_mp->L; l++) {
+    for (int l = 1; l <= cur_L; l++) {
+        int upper = intkl[l] + 1;
+        if (upper > MBE_MAX_HARMONIC_BANDS) {
+            upper = MBE_MAX_HARMONIC_BANDS;
+        }
         float c1 = (rho * ((float)1 - deltal[l]) * prev_mp->log2Ml[intkl[l]]);
-        float c2 = (rho * deltal[l] * prev_mp->log2Ml[intkl[l] + 1]);
+        float c2 = (rho * deltal[l] * prev_mp->log2Ml[upper]);
         cur_mp->log2Ml[l] = Tl[l] + c1 + c2 - Sum77;
         cur_mp->Ml[l] = exp2f(cur_mp->log2Ml[l]);
 #ifdef IMBE_DEBUG

--- a/tests/test_input_validation.c
+++ b/tests/test_input_validation.c
@@ -20,6 +20,41 @@ init_params(mbe_parms* cur, mbe_parms* prev, mbe_parms* enh) {
 }
 
 static void
+set_imbe7200_b0(char imbe_d[88], int b0) {
+    for (int i = 0; i < 8; ++i) {
+        int bit = (b0 >> (7 - i)) & 1;
+        if (i < 6) {
+            imbe_d[i] = (char)bit;
+        } else if (i == 6) {
+            imbe_d[85] = (char)bit;
+        } else {
+            imbe_d[86] = (char)bit;
+        }
+    }
+}
+
+static void
+set_valid_ambe_tone_bits(char ambe_d[49]) {
+    memset(ambe_d, 0, 49u);
+    ambe_d[6] = 1;
+    ambe_d[7] = 1;
+    ambe_d[8] = 1;
+    ambe_d[9] = 1;
+    ambe_d[10] = 1;
+    ambe_d[11] = 1;
+    ambe_d[17] = 1;
+    ambe_d[19] = 1;
+    ambe_d[44] = 1;
+}
+
+static void
+fill_float_buffer(float* out, float value) {
+    for (int i = 0; i < 160; ++i) {
+        out[i] = value;
+    }
+}
+
+static void
 assert_float_buffer_unchanged(const float* out, float value) {
     for (int i = 0; i < 160; ++i) {
         assert(out[i] == value);
@@ -231,6 +266,170 @@ test_invalid_harmonic_counts_rejected_by_raw_helpers(void) {
 }
 
 static void
+test_imbe_previous_harmonic_count_is_clamped_for_processing(void) {
+    static const int invalid_l_values[] = {-1, 0, 57, 1000};
+
+    for (size_t i = 0; i < sizeof(invalid_l_values) / sizeof(invalid_l_values[0]); ++i) {
+        char params[88] = {0};
+        float out[160];
+        mbe_process_result result;
+        mbe_parms cur = {0}, prev = {0}, enh = {0};
+
+        set_imbe7200_b0(params, 206);
+        init_params(&cur, &prev, &enh);
+        mbe_initProcessResult(&result);
+        prev.L = invalid_l_values[i];
+        prev.Ml[1] = 1.5f;
+        prev.log2Ml[1] = 0.25f;
+        prev.Ml[56] = 2.5f;
+        prev.log2Ml[56] = 0.5f;
+        fill_float_buffer(out, 123.0f);
+
+        assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8) >= 0);
+        assert(cur.L == 56);
+    }
+}
+
+static void
+test_imbe_previous_harmonic_count_upper_endpoint_is_safe(void) {
+    char params[88] = {0};
+    float out[160];
+    mbe_process_result result;
+    mbe_parms cur = {0}, prev = {0}, enh = {0};
+
+    set_imbe7200_b0(params, 206);
+    init_params(&cur, &prev, &enh);
+    mbe_initProcessResult(&result);
+    prev.L = 56;
+    prev.Ml[56] = 3.0f;
+    prev.log2Ml[56] = 1.0f;
+    fill_float_buffer(out, 123.0f);
+
+    assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8) >= 0);
+    assert(cur.L == 56);
+}
+
+static void
+stamp_params(mbe_parms* mp, int marker) {
+    mp->w0 = (float)marker + 0.25f;
+    mp->L = marker;
+    mp->K = marker + 1;
+    mp->Vl[1] = marker + 2;
+    mp->Ml[1] = (float)marker + 0.5f;
+    mp->log2Ml[1] = (float)marker + 0.75f;
+    mp->PHIl[1] = (float)marker + 1.0f;
+    mp->PSIl[1] = (float)marker + 1.25f;
+    mp->gamma = (float)marker + 1.5f;
+    mp->un = marker + 3;
+    mp->repeat = marker + 4;
+    mp->swn = marker + 5;
+    mp->localEnergy = (float)marker + 1.75f;
+    mp->amplitudeThreshold = marker + 6;
+    mp->errorRate = (float)marker + 2.0f;
+    mp->errorCountTotal = marker + 7;
+    mp->errorCount4 = marker + 8;
+    mp->repeatCount = marker + 9;
+    mp->mutingThreshold = (float)marker + 2.25f;
+    mp->previousUw[0] = (float)marker + 2.5f;
+    mp->noiseSeed = (float)marker + 2.75f;
+    mp->noiseOverlap[0] = (float)marker + 3.0f;
+}
+
+static void
+assert_params_stamp(const mbe_parms* mp, int marker) {
+    assert(mp->w0 == (float)marker + 0.25f);
+    assert(mp->L == marker);
+    assert(mp->K == marker + 1);
+    assert(mp->Vl[1] == marker + 2);
+    assert(mp->Ml[1] == (float)marker + 0.5f);
+    assert(mp->log2Ml[1] == (float)marker + 0.75f);
+    assert(mp->PHIl[1] == (float)marker + 1.0f);
+    assert(mp->PSIl[1] == (float)marker + 1.25f);
+    assert(mp->gamma == (float)marker + 1.5f);
+    assert(mp->un == marker + 3);
+    assert(mp->repeat == marker + 4);
+    assert(mp->swn == marker + 5);
+    assert(mp->localEnergy == (float)marker + 1.75f);
+    assert(mp->amplitudeThreshold == marker + 6);
+    assert(mp->errorRate == (float)marker + 2.0f);
+    assert(mp->errorCountTotal == marker + 7);
+    assert(mp->errorCount4 == marker + 8);
+    assert(mp->repeatCount == marker + 9);
+    assert(mp->mutingThreshold == (float)marker + 2.25f);
+    assert(mp->previousUw[0] == (float)marker + 2.5f);
+    assert(mp->noiseSeed == (float)marker + 2.75f);
+    assert(mp->noiseOverlap[0] == (float)marker + 3.0f);
+}
+
+static void
+test_null_parameter_helpers_are_noops(void) {
+    mbe_parms cur = {0}, prev = {0}, enh = {0}, src = {0}, dst = {0};
+
+    init_params(&cur, &prev, &enh);
+    stamp_params(&cur, 10);
+    stamp_params(&prev, 20);
+    stamp_params(&enh, 30);
+
+    mbe_initMbeParms(NULL, &prev, &enh);
+    assert_params_stamp(&prev, 20);
+    assert_params_stamp(&enh, 30);
+
+    mbe_initMbeParms(&cur, NULL, &enh);
+    assert_params_stamp(&cur, 10);
+    assert_params_stamp(&enh, 30);
+
+    mbe_initMbeParms(&cur, &prev, NULL);
+    assert_params_stamp(&cur, 10);
+    assert_params_stamp(&prev, 20);
+    mbe_initMbeParms(NULL, NULL, NULL);
+
+    stamp_params(&src, 40);
+    stamp_params(&dst, 50);
+    mbe_moveMbeParms(NULL, &dst);
+    assert_params_stamp(&dst, 50);
+    mbe_moveMbeParms(&src, NULL);
+    mbe_moveMbeParms(NULL, NULL);
+
+    mbe_moveMbeParms(&src, &dst);
+    assert_params_stamp(&dst, 40);
+
+    stamp_params(&dst, 60);
+    mbe_useLastMbeParms(&dst, NULL);
+    assert_params_stamp(&dst, 60);
+    mbe_useLastMbeParms(NULL, &src);
+    mbe_useLastMbeParms(NULL, NULL);
+}
+
+static void
+test_tone_helpers_silence_invalid_inputs(void) {
+    char ambe_d[49];
+    float out[160];
+    mbe_parms cur = {0}, prev = {0}, enh = {0};
+
+    init_params(&cur, &prev, &enh);
+    set_valid_ambe_tone_bits(ambe_d);
+
+    fill_float_buffer(out, 123.0f);
+    mbe_synthesizeTonef(out, NULL, &cur);
+    assert_float_buffer_unchanged(out, 0.0f);
+
+    set_valid_ambe_tone_bits(ambe_d);
+    ambe_d[0] = 2;
+    fill_float_buffer(out, 123.0f);
+    mbe_synthesizeTonef(out, ambe_d, &cur);
+    assert_float_buffer_unchanged(out, 0.0f);
+
+    set_valid_ambe_tone_bits(ambe_d);
+    fill_float_buffer(out, 123.0f);
+    mbe_synthesizeTonef(out, ambe_d, NULL);
+    assert_float_buffer_unchanged(out, 0.0f);
+
+    fill_float_buffer(out, 123.0f);
+    mbe_synthesizeTonefdstar(out, ambe_d, NULL, 5);
+    assert_float_buffer_unchanged(out, 0.0f);
+}
+
+static void
 test_low_level_public_bit_paths_validate(void) {
     char ambe_frame[4][24] = {{0}};
     char imbe7100_frame[7][24] = {{0}};
@@ -261,6 +460,10 @@ main(void) {
     test_invalid_parameter_bits_rejected_before_synthesis();
     test_invalid_result_context_rejected();
     test_invalid_harmonic_counts_rejected_by_raw_helpers();
+    test_imbe_previous_harmonic_count_is_clamped_for_processing();
+    test_imbe_previous_harmonic_count_upper_endpoint_is_safe();
+    test_null_parameter_helpers_are_noops();
+    test_tone_helpers_silence_invalid_inputs();
     test_low_level_public_bit_paths_validate();
     return 0;
 }


### PR DESCRIPTION
## Summary

- Clamp IMBE spectral interpolation harmonic counts and bounded previous-state bin lookups.
- Make public parameter helper and tone synthesis helpers defensive for null or invalid inputs without changing ABI.
- Add regression coverage for corrupted IMBE previous-state counts, helper no-op behavior, and tone silence fallback.
- Run ClusterFuzzLite PR fuzzing with both ASan and UBSan.

## Validation

- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `cmake --preset asan-ubsan-debug`
- `cmake --build --preset asan-ubsan-debug -j`
- `ctest --preset asan-ubsan-debug --output-on-failure`
- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- pre-push changed-file checks: workflow pin guards, clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, workflow lint, zizmor, Lizard

## Repository Settings

- Enabled required SHA pinning for GitHub Actions while leaving Actions enabled and `allowed_actions=all`.