### PR TITLE
Harden release checks and simplify version API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,29 @@ jobs:
         run: cmake --build --preset ${{ matrix.preset }} --parallel
       - name: Test (${{ matrix.preset }})
         run: ctest --preset ${{ matrix.preset }} -V
-      - name: Verify release hardening
-        if: matrix.os == 'ubuntu-latest' && matrix.preset == 'dev-release'
+      - name: Verify release hardening (Unix)
+        if: matrix.os != 'windows-latest' && matrix.preset == 'dev-release'
         run: |
-          tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release
+          case "${RUNNER_OS}" in
+            Linux) lib_path="build/dev-release/libmbe-neo.so" ;;
+            macOS) lib_path="build/dev-release/libmbe-neo.dylib" ;;
+            *)
+              echo "Unsupported Unix runner OS: ${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
+          tools/check_release_hardening.sh "${lib_path}" build/dev-release
           tools/check_release_hardening.sh build/dev-release/example_print_version build/dev-release
+      - name: Verify release hardening (Windows)
+        if: matrix.os == 'windows-latest' && matrix.preset == 'dev-release'
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem -Path build/dev-release -Filter mbe-neo.dll -Recurse | Select-Object -First 1
+          $exe = Get-ChildItem -Path build/dev-release -Filter example_print_version.exe -Recurse | Select-Object -First 1
+          if ($null -eq $dll) { throw "mbe-neo.dll not found under build/dev-release" }
+          if ($null -eq $exe) { throw "example_print_version.exe not found under build/dev-release" }
+          ./tools/check_release_hardening.ps1 $dll.FullName
+          ./tools/check_release_hardening.ps1 $exe.FullName
 
   sanitize-linux:
     needs: [format-check, clang-tidy, cppcheck, lizard, scan-build, semgrep]
@@ -582,8 +600,7 @@ jobs:
           #include <stdio.h>
           #include <mbelib-neo/mbelib.h>
           int main(void) {
-            char ver[32] = {0};
-            mbe_printVersion(ver);
+            const char *ver = mbe_versionString();
             printf("version: %s\n", ver);
             return ver[0] ? 0 : 1;
           }
@@ -605,8 +622,7 @@ jobs:
           #include <stdio.h>
           #include <mbelib-neo/mbelib.h>
           int main(void) {
-            char ver[32] = {0};
-            mbe_printVersion(ver);
+            const char *ver = mbe_versionString();
             printf("version: %s\n", ver);
             return ver[0] ? 0 : 1;
           }
@@ -643,8 +659,7 @@ jobs:
           #include <stdio.h>
           #include <mbelib-neo/mbelib.h>
           int main(void) {
-            char ver[32] = {0};
-            mbe_printVersion(ver);
+            const char *ver = mbe_versionString();
             printf("version: %s\n", ver);
             return ver[0] ? 0 : 1;
           }
@@ -679,11 +694,29 @@ jobs:
         run: cmake --build --preset dev-release --parallel
       - name: Test (dev-release preset)
         run: ctest --preset dev-release -V
-      - name: Verify release hardening
-        if: runner.os == 'Linux'
+      - name: Verify release hardening (Unix)
+        if: runner.os != 'Windows'
         run: |
-          tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release
+          case "${RUNNER_OS}" in
+            Linux) lib_path="build/dev-release/libmbe-neo.so" ;;
+            macOS) lib_path="build/dev-release/libmbe-neo.dylib" ;;
+            *)
+              echo "Unsupported Unix runner OS: ${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
+          tools/check_release_hardening.sh "${lib_path}" build/dev-release
           tools/check_release_hardening.sh build/dev-release/example_print_version build/dev-release
+      - name: Verify release hardening (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem -Path build/dev-release -Filter mbe-neo.dll -Recurse | Select-Object -First 1
+          $exe = Get-ChildItem -Path build/dev-release -Filter example_print_version.exe -Recurse | Select-Object -First 1
+          if ($null -eq $dll) { throw "mbe-neo.dll not found under build/dev-release" }
+          if ($null -eq $exe) { throw "example_print_version.exe not found under build/dev-release" }
+          ./tools/check_release_hardening.ps1 $dll.FullName
+          ./tools/check_release_hardening.ps1 $exe.FullName
       - name: Compute bundle name
         id: bundle
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,51 +158,70 @@ if(MBELIB_ENABLE_HARDENING AND (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU"))
 endif()
 
 function(_mbelib_apply_hardening target)
-    if(
-        NOT MBELIB_ENABLE_HARDENING
-        OR NOT (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
-    )
+    if(NOT MBELIB_ENABLE_HARDENING)
         return()
     endif()
 
-    _mbelib_flags_define_fortify(_mbelib_c_flags_define_fortify)
-    if(NOT _mbelib_c_flags_define_fortify)
-        target_compile_definitions(
-            ${target}
-            PRIVATE "$<${_mbelib_release_like_config}:_FORTIFY_SOURCE=2>"
-        )
-    endif()
-
-    if(MBELIB_C_HAS_STACK_PROTECTOR_STRONG)
-        target_compile_options(
-            ${target}
-            PRIVATE "$<${_mbelib_release_like_config}:-fstack-protector-strong>"
-        )
-    endif()
-    if(NOT APPLE AND MBELIB_C_HAS_STACK_CLASH_PROTECTION)
-        target_compile_options(
-            ${target}
-            PRIVATE "$<${_mbelib_release_like_config}:-fstack-clash-protection>"
-        )
-    endif()
-
     get_target_property(_mbelib_target_type ${target} TYPE)
-    if(
-        UNIX
-        AND NOT APPLE
+
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        _mbelib_flags_define_fortify(_mbelib_c_flags_define_fortify)
+        if(NOT _mbelib_c_flags_define_fortify)
+            target_compile_definitions(
+                ${target}
+                PRIVATE "$<${_mbelib_release_like_config}:_FORTIFY_SOURCE=2>"
+            )
+        endif()
+
+        if(MBELIB_C_HAS_STACK_PROTECTOR_STRONG)
+            target_compile_options(
+                ${target}
+                PRIVATE
+                    "$<${_mbelib_release_like_config}:-fstack-protector-strong>"
+            )
+        endif()
+        if(NOT APPLE AND MBELIB_C_HAS_STACK_CLASH_PROTECTION)
+            target_compile_options(
+                ${target}
+                PRIVATE
+                    "$<${_mbelib_release_like_config}:-fstack-clash-protection>"
+            )
+        endif()
+
+        if(
+            UNIX
+            AND NOT APPLE
+            AND NOT _mbelib_target_type STREQUAL "STATIC_LIBRARY"
+            AND NOT _mbelib_target_type STREQUAL "OBJECT_LIBRARY"
+        )
+            if(MBELIB_LD_HAS_RELRO)
+                target_link_options(
+                    ${target}
+                    PRIVATE "$<${_mbelib_release_like_config}:-Wl,-z,relro>"
+                )
+            endif()
+            if(MBELIB_LD_HAS_NOW)
+                target_link_options(
+                    ${target}
+                    PRIVATE "$<${_mbelib_release_like_config}:-Wl,-z,now>"
+                )
+            endif()
+        endif()
+    elseif(
+        MSVC
         AND NOT _mbelib_target_type STREQUAL "STATIC_LIBRARY"
         AND NOT _mbelib_target_type STREQUAL "OBJECT_LIBRARY"
     )
-        if(MBELIB_LD_HAS_RELRO)
+        target_link_options(
+            ${target}
+            PRIVATE
+                "$<${_mbelib_release_like_config}:/DYNAMICBASE>"
+                "$<${_mbelib_release_like_config}:/NXCOMPAT>"
+        )
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
             target_link_options(
                 ${target}
-                PRIVATE "$<${_mbelib_release_like_config}:-Wl,-z,relro>"
-            )
-        endif()
-        if(MBELIB_LD_HAS_NOW)
-            target_link_options(
-                ${target}
-                PRIVATE "$<${_mbelib_release_like_config}:-Wl,-z,now>"
+                PRIVATE "$<${_mbelib_release_like_config}:/HIGHENTROPYVA>"
             )
         endif()
     endif()

--- a/README.md
+++ b/README.md
@@ -157,10 +157,7 @@ Minimal example
 #include <mbelib-neo/mbelib.h>
 
 int main(void) {
-  char ver[32] = {0};
-  mbe_printVersion(ver);
-  printf("mbelib version: %s\n", ver);
-  // Or: puts(mbe_versionString());
+  printf("mbelib version: %s\n", mbe_versionString());
   return 0;
 }
 ```
@@ -200,7 +197,7 @@ IMBE 7100x4400 frame decoders convert their `imbe_d[88]` output to the 7200x4400
 - Use `mbe_formatProcessResult()` when you need a compact status string from a result. It writes `'='` repeated `total_errors` times, then any `E`, `T`, `R`, and `M` flags in that order, truncated to the supplied buffer size.
 - Hard input bits must be exactly `0` or `1`; soft `mbe_soft_bit.bit` values must also be exactly `0` or `1`. Invalid pointers/counters return `MBE_STATUS_INVALID_ARGUMENT`; invalid bit values return `MBE_STATUS_INVALID_BITS`.
 - For parameter-only processing, seed `mbe_process_result.total_errors` and any valid C0/C4 context before calling `mbe_process*Data*`.
-- `mbe_printVersion(char *str)` uses a legacy fixed write width of 32 bytes. Pass a buffer of at least 32 bytes, or prefer `mbe_versionString()` when possible.
+- Use `mbe_versionString()` for the static NUL-terminated library version string.
 
 ### Audio Sample Scaling (Float vs int16)
 
@@ -254,7 +251,7 @@ cmake --install build --prefix /mingw64
 cat > consumer.c << 'EOF'
 #include <stdio.h>
 #include <mbelib-neo/mbelib.h>
-int main(void) { char ver[32]={0}; mbe_printVersion(ver); printf("%s\n", ver); }
+int main(void) { printf("%s\n", mbe_versionString()); }
 EOF
 cc consumer.c $(pkg-config --cflags --libs libmbe-neo) -o consumer.exe
 ```
@@ -291,7 +288,7 @@ These improvements bring mbelib-neo's audio quality closer to the reference JMBE
 
 - Public API is prefixed `mbe_` and declared in `mbelib.h`.
 - Float and 16‑bit PCM variants are provided (e.g., `mbe_processAmbe3600x2400Framef` and `mbe_processAmbe3600x2400Frame`).
-- Version macro `MBELIB_VERSION` is defined in the generated header `mbelib-neo/version.h` and returned by `mbe_printVersion`.
+- Version macro `MBELIB_VERSION` is defined in the generated header `mbelib-neo/version.h`.
 - `mbe_versionString()` returns a const pointer to the version string.
 - Processing APIs return an `int` error total and use `mbe_process_result` for decode/synthesis status.
 - Soft-decision ECC helpers are public for Golay(23,12), Hamming(15,11), and the IMBE 7100x4400 Hamming mapping.

--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -32,7 +32,7 @@ Run the smallest useful set before opening a PR, then broaden it when the change
 - CMake changes: `tools/cmake_format_check.sh`.
 - Workflow changes: `tools/workflow_lint.sh` and `tools/zizmor.sh`.
 - Workflow source/download pin changes: `tools/check_workflow_git_pins.sh` and `tools/check_workflow_download_pins.sh`.
-- Release hardening changes: `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release`.
+- Release hardening changes: run `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release` on Linux and let CI verify macOS Mach-O and Windows PE release artifacts.
 - Dependency input changes: `tools/osv_scan.sh`.
 
 ## Required PR Status Checks

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -72,8 +72,8 @@ The project applies the following controls:
   architecture detection
 - sanitizer CI for AddressSanitizer and UndefinedBehaviorSanitizer
 - ClusterFuzzLite PR fuzzing with AddressSanitizer for frame-processing paths
-- default-on Release-like compiler/linker hardening for supported Clang/GCC
-  targets, with Linux release verification in CI
+- default-on Release-like compiler/linker hardening for supported Clang, GCC,
+  and MSVC targets, with release verification in CI
 - static analysis through CodeQL, Semgrep, clang-tidy, cppcheck, scan-build,
   GCC `-fanalyzer`, and include-what-you-use
 - Gitleaks and GitHub secret scanning for credential leakage

--- a/examples/print_version.c
+++ b/examples/print_version.c
@@ -12,8 +12,6 @@
  */
 int
 main(void) {
-    char ver[32] = {0};
-    mbe_printVersion(ver);
-    printf("mbelib version: %s\n", ver);
+    printf("mbelib version: %s\n", mbe_versionString());
     return 0;
 }

--- a/include/mbelib-neo/mbelib.h
+++ b/include/mbelib-neo/mbelib.h
@@ -590,14 +590,6 @@ MBE_API int mbe_processImbe7100x4400SoftFrame(short* aout_buf, mbe_process_resul
                                               const mbe_soft_bit imbe_fr[7][24], char imbe_d[88], mbe_parms* cur_mp,
                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
 
-/* Prototypes from mbelib.c */
-/**
- * @brief Write the mbelib-neo version string into the provided buffer.
- * @param str Output buffer receiving a NUL-terminated version string.
- *            The current ABI writes up to 31 characters plus NUL; provide at
- *            least 32 bytes.
- */
-MBE_API void mbe_printVersion(char* str);
 /**
  * @brief Get a pointer to a static NUL-terminated version string.
  *        The returned pointer remains valid for the lifetime of the program.

--- a/src/core/mbelib.c
+++ b/src/core/mbelib.c
@@ -26,8 +26,10 @@
 
 #include <math.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
+#ifdef MBE_DEBUG
+#include <stdio.h>
+#endif
 #include "mbe_compiler.h"
 #if defined(MBELIB_ENABLE_SIMD)
 #if defined(MBE_SIMD_TARGET_SSE2)
@@ -308,24 +310,8 @@ mbe_add_voiced_dual_block4(float* restrict Ss, const float* restrict W_prev, flo
 #endif
 }
 
-/**
- * @brief Write the library version string into the provided buffer.
- * @param str Output buffer receiving a NUL-terminated version string.
- *            The current ABI writes up to 31 characters plus NUL; provide at
- *            least 32 bytes.
- */
-void
-mbe_printVersion(char* str) {
-    if (!str) {
-        return;
-    }
-    /* Ensure we never overrun caller buffer; tests pass a 32B buffer. */
-    (void)snprintf(str, 32, "%s", MBELIB_VERSION);
-}
-
 /** @} */ /* end of mbe_internal */
 
-/* Convenience accessor that avoids buffer management. */
 const char*
 mbe_versionString(void) {
     return MBELIB_VERSION;

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -13,13 +13,11 @@
 #include "mbelib-neo/version.h"
 
 /**
- * @brief Test entry: verifies mbe_printVersion matches MBELIB_VERSION.
+ * @brief Test entry: verifies version helpers match MBELIB_VERSION.
  */
 int
 main(void) {
-    char ver[32] = {0};
-    mbe_printVersion(ver);
-    assert(strcmp(ver, MBELIB_VERSION) == 0);
+    assert(strcmp(mbe_versionString(), MBELIB_VERSION) == 0);
 
     mbe_process_result result;
     mbe_initProcessResult(&result);

--- a/tools/check_release_hardening.ps1
+++ b/tools/check_release_hardening.ps1
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Artifact
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-Dumpbin {
+    $command = Get-Command dumpbin.exe -ErrorAction SilentlyContinue
+    if ($null -ne $command) {
+        return $command.Source
+    }
+
+    $vswherePaths = @()
+    if (${env:ProgramFiles(x86)}) {
+        $vswherePaths += Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    }
+    if ($env:ProgramFiles) {
+        $vswherePaths += Join-Path $env:ProgramFiles "Microsoft Visual Studio\Installer\vswhere.exe"
+    }
+
+    foreach ($vswhere in $vswherePaths) {
+        if (-not (Test-Path -LiteralPath $vswhere)) {
+            continue
+        }
+
+        $installationPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $installationPath) {
+            continue
+        }
+
+        $toolRoot = Join-Path $installationPath "VC\Tools\MSVC"
+        if (-not (Test-Path -LiteralPath $toolRoot)) {
+            continue
+        }
+
+        $candidate = Get-ChildItem -LiteralPath $toolRoot -Filter dumpbin.exe -Recurse |
+            Where-Object { $_.FullName -match "\\Hostx64\\x64\\dumpbin\.exe$" } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+        if ($null -ne $candidate) {
+            return $candidate.FullName
+        }
+    }
+
+    throw "dumpbin.exe not found. Run from a Visual Studio developer shell or install MSVC build tools."
+}
+
+if (-not (Test-Path -LiteralPath $Artifact)) {
+    throw "release artifact not found: $Artifact"
+}
+
+$dumpbin = Resolve-Dumpbin
+$headers = & $dumpbin /headers $Artifact 2>&1 | Out-String
+if ($LASTEXITCODE -ne 0) {
+    throw "dumpbin failed for $Artifact"
+}
+
+if ($headers -notmatch "Dynamic base") {
+    throw "release artifact is missing PE Dynamic base (ASLR): $Artifact"
+}
+if ($headers -notmatch "NX compatible") {
+    throw "release artifact is missing PE NX compatible: $Artifact"
+}
+
+$is64Bit = $headers -match "machine \((x64|ARM64|ARM64EC)\)" -or $headers -match "(8664|AA64|A64E) machine"
+if ($is64Bit -and $headers -notmatch "High Entropy Virtual Addresses") {
+    throw "64-bit release artifact is missing PE High Entropy Virtual Addresses: $Artifact"
+}
+
+Write-Host "Windows PE hardening OK: $Artifact"

--- a/tools/check_release_hardening.sh
+++ b/tools/check_release_hardening.sh
@@ -21,10 +21,47 @@ if [[ -f "$compile_db" ]]; then
   fi
 fi
 
-if [[ "$(uname -s)" != "Linux" ]]; then
-  echo "ELF hardening checks are Linux-only; compile flag checks completed."
-  exit 0
-fi
+check_macho_hardening() {
+  if ! command -v otool > /dev/null 2>&1; then
+    echo "otool is required for Mach-O hardening checks." >&2
+    exit 2
+  fi
+
+  local header
+  header="$(otool -hv "$artifact")"
+  if printf '%s\n' "$header" | grep -Eq '(^|[[:space:]])(MH_)?DYLIB([[:space:]]|$)'; then
+    local install_name
+    install_name="$(otool -D "$artifact" | sed -n '2p')"
+    if [[ ! "$install_name" == @rpath/* ]]; then
+      echo "Mach-O dylib install name must use @rpath; got '${install_name:-<none>}'." >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  if printf '%s\n' "$header" | grep -q 'EXECUTE'; then
+    if ! printf '%s\n' "$header" | grep -q 'PIE'; then
+      echo "Mach-O executable is missing PIE flag." >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  echo "Unsupported Mach-O artifact type in $artifact." >&2
+  exit 1
+}
+
+case "$(uname -s)" in
+  Linux) ;;
+  Darwin)
+    check_macho_hardening
+    exit 0
+    ;;
+  *)
+    echo "ELF hardening checks are Linux-only; compile flag checks completed."
+    exit 0
+    ;;
+esac
 
 if ! command -v readelf > /dev/null 2>&1; then
   echo "readelf is required for ELF hardening checks." >&2


### PR DESCRIPTION
## Summary
- remove the legacy unsized version-copy API and use `mbe_versionString()` in examples, tests, docs, and CI consumers
- add explicit MSVC linker hardening flags for release-like PE artifacts
- extend release hardening checks to Linux ELF, macOS Mach-O, and Windows PE artifacts

## Validation
- `cmake --preset dev-release`
- `cmake --build --preset dev-release --parallel`
- `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release`
- `tools/check_release_hardening.sh build/dev-release/example_print_version build/dev-release`
- `ctest --preset dev-release --output-on-failure`
- `cmake --build --preset dev-debug --parallel`
- `ctest --preset dev-debug --output-on-failure`
- `cmake --build --preset asan-ubsan-debug --parallel`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ctest --preset asan-ubsan-debug --output-on-failure`
- `tools/workflow_lint.sh`
- `tools/shell_lint.sh`
- `tools/cmake_format_check.sh`
- `tools/check_workflow_git_pins.sh`
- `tools/check_workflow_download_pins.sh`
- `tools/zizmor.sh`
- `tools/semgrep.sh --strict`
- `tools/osv_scan.sh`
- `tools/gitleaks.sh`