### PR TITLE
Tighten strict rules and prune legacy v2 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,6 @@ option(
     OFF
 )
 option(MBELIB_BUILD_BENCHMARKS "Build micro-benchmarks (not run in CI)" OFF)
-option(
-    MBELIB_STRICT_ORDER
-    "Reserved compatibility flag (currently no behavior change)"
-    OFF
-)
-
 # Warnings
 if(MBELIB_ENABLE_WARNINGS)
     if(MSVC)
@@ -105,7 +99,16 @@ if(MBELIB_ENABLE_WARNINGS)
             add_compile_options(/WX)
         endif()
     elseif(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU|IntelLLVM")
-        add_compile_options(-Wall -Wextra -Wpedantic)
+        add_compile_options(
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wformat=2
+            -Wvla
+            -Wstrict-prototypes
+            -Wmissing-prototypes
+            -Wold-style-definition
+        )
         if(MBELIB_WARNINGS_AS_ERRORS)
             add_compile_options(-Werror)
         endif()
@@ -238,6 +241,12 @@ configure_file(
 
 # PFFFT sources (bundled, BSD-like FFTPACK license)
 set(PFFFT_SOURCES src/external/pffft/pffft.c src/external/pffft/fftpack.c)
+if(MBELIB_ENABLE_WARNINGS AND CMAKE_C_COMPILER_ID MATCHES "Clang|GNU|IntelLLVM")
+    set_source_files_properties(
+        ${PFFFT_SOURCES}
+        PROPERTIES COMPILE_OPTIONS "-Wno-missing-prototypes;-Wno-vla"
+    )
+endif()
 
 # Explicit source lists (avoids FILE(GLOB ...))
 set(MBELIB_FIRST_PARTY_SOURCES
@@ -326,15 +335,6 @@ if(NOTONES)
         PRIVATE DISABLE_AMBE_TONES
     )
 endif()
-if(MBELIB_STRICT_ORDER)
-    target_compile_definitions(mbe-shared PRIVATE MBELIB_STRICT_ORDER=1)
-    target_compile_definitions(mbe-static PRIVATE MBELIB_STRICT_ORDER=1)
-    target_compile_definitions(
-        mbe-codeql-first-party
-        PRIVATE MBELIB_STRICT_ORDER=1
-    )
-endif()
-
 # Documentation (Doxygen)
 if(MBELIB_BUILD_DOCS)
     find_package(Doxygen QUIET)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ git push origin vX.Y.Z
 - `-DMBELIB_ENABLE_LTO=ON` — Enable IPO/LTO in Release builds when supported.
 - `-DMBELIB_ENABLE_HARDENING=ON` — Enable supported Release-like compiler/linker hardening (default ON).
 - `-DMBELIB_ENABLE_SIMD=ON` — Enable SIMD-accelerated routines in hot paths (SSE2 on x86_64, NEON on ARM64, and SSE2-targeted builds on 32-bit x86). On 32-bit x86, this option compiles the library for SSE2 and therefore requires an SSE2-capable CPU; leave it OFF for baseline i386 portability.
-- `-DMBELIB_STRICT_ORDER=ON` — Compatibility flag that currently only defines `MBELIB_STRICT_ORDER` at compile time (no behavior change in this tree).
 - Note: the `dev-release` preset enables SIMD, fast-math, and LTO by default when supported.
 - `-DMBELIB_BUILD_BENCHMARKS=ON` — Build optional local micro‑benchmarks (not run in CI): `bench_synth`, `bench_unvoiced`, and `bench_convert`.
 

--- a/bench/bench_convert.c
+++ b/bench/bench_convert.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <time.h>
 
+#include "bench_parse.h"
 #include "mbelib-neo/mbelib.h"
 
 /**
@@ -30,8 +31,9 @@ secs(void) {
 int
 main(int argc, char** argv) {
     int loops = 200000; // convert 200k frames -> ~32M samples
-    if (argc > 1) {
-        loops = atoi(argv[1]);
+    if (argc > 1 && bench_parse_int_arg(argv[1], 1, INT_MAX, &loops) < 0) {
+        fprintf(stderr, "usage: %s [loops]\n", argv[0]);
+        return 2;
     }
     float f[160];
     short s[160];

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef MBELIB_NEO_BENCH_PARSE_H
+#define MBELIB_NEO_BENCH_PARSE_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
+static inline int
+bench_parse_int_arg(const char* text, int min_value, int max_value, int* out_value) {
+    char* end = NULL;
+    long value;
+
+    if (!text || !out_value || min_value > max_value) {
+        return -1;
+    }
+
+    errno = 0;
+    value = strtol(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || value < (long)min_value || value > (long)max_value) {
+        return -1;
+    }
+
+    *out_value = (int)value;
+    return 0;
+}
+
+#endif /* MBELIB_NEO_BENCH_PARSE_H */

--- a/bench/bench_synth.c
+++ b/bench/bench_synth.c
@@ -62,7 +62,7 @@ main(void) {
                 cur.Vl[l] = ((i + l) % 5) ? 1 : 0;
                 cur.Ml[l] = 0.04f + 0.003f * (float)((i + l) % 7);
             }
-            mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+            mbe_synthesizeSpeechf(out, &cur, &prev);
             mbe_moveMbeParms(&cur, &prev);
         }
         double dt = secs() - t0;

--- a/bench/bench_unvoiced.c
+++ b/bench/bench_unvoiced.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <time.h>
 
+#include "bench_parse.h"
 #include "mbelib-neo/mbelib.h"
 
 /**
@@ -59,18 +60,17 @@ main(int argc, char** argv) {
     int iters = 2000;
     int runs = 8;
     int L = 36;
-    int uvq = 8;
-    if (argc > 1) {
-        uvq = atoi(argv[1]);
+    if (argc > 1 && bench_parse_int_arg(argv[1], 8, 56, &L) < 0) {
+        fprintf(stderr, "usage: %s [L] [iters] [runs]\n", argv[0]);
+        return 2;
     }
-    if (argc > 2) {
-        L = atoi(argv[2]);
+    if (argc > 2 && bench_parse_int_arg(argv[2], 1, INT_MAX, &iters) < 0) {
+        fprintf(stderr, "usage: %s [L] [iters] [runs]\n", argv[0]);
+        return 2;
     }
-    if (argc > 3) {
-        iters = atoi(argv[3]);
-    }
-    if (argc > 4) {
-        runs = atoi(argv[4]);
+    if (argc > 3 && bench_parse_int_arg(argv[3], 1, INT_MAX, &runs) < 0) {
+        fprintf(stderr, "usage: %s [L] [iters] [runs]\n", argv[0]);
+        return 2;
     }
 
     float out[160];
@@ -84,7 +84,7 @@ main(int argc, char** argv) {
         for (int i = 0; i < iters; ++i) {
             // Wiggle w0 a bit to avoid degenerate recurrence
             cur.w0 = (i & 1) ? 0.10f : 0.12f;
-            mbe_synthesizeSpeechf(out, &cur, &prev, uvq);
+            mbe_synthesizeSpeechf(out, &cur, &prev);
             mbe_moveMbeParms(&cur, &prev);
         }
         double dt = secs() - t0;
@@ -97,7 +97,6 @@ main(int argc, char** argv) {
         }
         printf("run %d: %.6f s\n", r + 1, dt);
     }
-    printf("uvq=%d L=%d frames=%d -> avg: %.6f s, best: %.6f s, worst: %.6f s\n", uvq, L, iters * runs, total / runs,
-           best, worst);
+    printf("L=%d frames=%d -> avg: %.6f s, best: %.6f s, worst: %.6f s\n", L, iters * runs, total / runs, best, worst);
     return 0;
 }

--- a/fuzz/fuzz_frame_decode.cc
+++ b/fuzz/fuzz_frame_decode.cc
@@ -53,15 +53,13 @@ struct FuzzState {
     mbe_parms prev_enh = {};
     float out[160] = {};
     mbe_process_result result = {};
-    int uvquality = 8;
     bool raw_bits = false;
 };
 
 static FuzzState
-make_state(const std::uint8_t* data, std::size_t size) {
+make_state(const std::uint8_t* data) {
     FuzzState state = {};
     init_state(&state.cur, &state.prev, &state.prev_enh);
-    state.uvquality = (size > 1U) ? static_cast<int>((data[1] % 8U) + 1U) : 8;
     state.raw_bits = (data[0] & 0x80U) != 0U;
     return state;
 }
@@ -88,7 +86,7 @@ run_ambe2400_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[49] = {};
             fill_hard_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processAmbe3600x2400Framef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                 &state.prev_enh, state.uvquality);
+                                                 &state.prev_enh);
             break;
         }
         default: {
@@ -96,7 +94,7 @@ run_ambe2400_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[49] = {};
             fill_soft_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processAmbe3600x2400SoftFramef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                     &state.prev_enh, state.uvquality);
+                                                     &state.prev_enh);
             break;
         }
     }
@@ -124,7 +122,7 @@ run_ambe2450_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[49] = {};
             fill_hard_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processAmbe3600x2450Framef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                 &state.prev_enh, state.uvquality);
+                                                 &state.prev_enh);
             break;
         }
         default: {
@@ -132,7 +130,7 @@ run_ambe2450_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[49] = {};
             fill_soft_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processAmbe3600x2450SoftFramef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                     &state.prev_enh, state.uvquality);
+                                                     &state.prev_enh);
             break;
         }
     }
@@ -160,7 +158,7 @@ run_imbe7200_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[88] = {};
             fill_hard_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processImbe7200x4400Framef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                 &state.prev_enh, state.uvquality);
+                                                 &state.prev_enh);
             break;
         }
         default: {
@@ -168,7 +166,7 @@ run_imbe7200_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[88] = {};
             fill_soft_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processImbe7200x4400SoftFramef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                     &state.prev_enh, state.uvquality);
+                                                     &state.prev_enh);
             break;
         }
     }
@@ -196,7 +194,7 @@ run_imbe7100_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[88] = {};
             fill_hard_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processImbe7100x4400Framef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                 &state.prev_enh, state.uvquality);
+                                                 &state.prev_enh);
             break;
         }
         default: {
@@ -204,7 +202,7 @@ run_imbe7100_case(std::uint8_t mode, FuzzState& state, const std::uint8_t* data,
             char bits[88] = {};
             fill_soft_frame(frame, data, size, 2U, state.raw_bits);
             (void)mbe_processImbe7100x4400SoftFramef(state.out, &state.result, frame, bits, &state.cur, &state.prev,
-                                                     &state.prev_enh, state.uvquality);
+                                                     &state.prev_enh);
             break;
         }
     }
@@ -216,7 +214,7 @@ LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
         return 0;
     }
 
-    FuzzState state = make_state(data, size);
+    FuzzState state = make_state(data);
     const std::uint8_t choice = data[0] % 16U;
     const std::uint8_t mode = choice % 4U;
 

--- a/fuzz/fuzz_process_frame.cc
+++ b/fuzz/fuzz_process_frame.cc
@@ -39,26 +39,25 @@ LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
     float out[160] = {};
     mbe_process_result result = {};
     result.total_errors = (size > 1U) ? static_cast<int>(data[1] & 0x0FU) : 0;
-    const int uvquality = (size > 2U) ? static_cast<int>((data[2] % 8U) + 1U) : 8;
     const bool raw_bits = (data[0] & 0x80U) != 0U;
 
     switch (data[0] % 3U) {
         case 0: {
             char imbe_d[88];
             fill_bits(imbe_d, sizeof(imbe_d), data, size, 3U, raw_bits);
-            (void)mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, uvquality);
+            (void)mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh);
             break;
         }
         case 1: {
             char ambe_d[49];
             fill_bits(ambe_d, sizeof(ambe_d), data, size, 3U, raw_bits);
-            (void)mbe_processAmbe2400Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh, uvquality);
+            (void)mbe_processAmbe2400Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh);
             break;
         }
         default: {
             char ambe_d[49];
             fill_bits(ambe_d, sizeof(ambe_d), data, size, 3U, raw_bits);
-            (void)mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh, uvquality);
+            (void)mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh);
             break;
         }
     }

--- a/include/mbelib-neo/mbelib.h
+++ b/include/mbelib-neo/mbelib.h
@@ -104,10 +104,8 @@ struct mbe_parameters {
     float PSIl[57];
     /** Spectral amplitude enhancement scale. */
     float gamma;
-    /** Legacy/unused field; retained for ABI compatibility. */
-    int un;
-    /** Repeat frame flag (legacy - use repeatCount instead). */
-    int repeat;
+    /** Tone synthesis phase accumulator. */
+    uint32_t tonePhase;
     /** Sine wave increment for tone synthesis. */
     int swn;
 
@@ -332,17 +330,16 @@ MBE_API int mbe_decodeAmbe3600x2400SoftFrame(const mbe_soft_bit ambe_fr[4][24], 
  * @param cur_mp   In/out: current frame parameters (may be enhanced).
  * @param prev_mp  In/out: previous frame parameters.
  * @param prev_mp_enhanced In/out: enhanced previous parameters for continuity.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processAmbe2400Dataf(float* aout_buf, mbe_process_result* result, const char ambe_d[49],
-                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process AMBE 2400 parameters into 8 kHz 16-bit PCM.
  * @see mbe_processAmbe2400Dataf for details.
  */
 MBE_API int mbe_processAmbe2400Data(short* aout_buf, mbe_process_result* result, const char ambe_d[49],
-                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a complete AMBE 3600x2400 frame into 8 kHz float PCM.
  * @param aout_buf Output buffer of 160 float samples.
@@ -350,19 +347,18 @@ MBE_API int mbe_processAmbe2400Data(short* aout_buf, mbe_process_result* result,
  * @param ambe_fr  Input frame as 4x24 bitplanes.
  * @param ambe_d   Scratch/output parameter bits (49).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processAmbe3600x2400Framef(float* aout_buf, mbe_process_result* result, const char ambe_fr[4][24],
                                            char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                           mbe_parms* prev_mp_enhanced, int uvquality);
+                                           mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a complete AMBE 3600x2400 frame into 8 kHz 16-bit PCM.
  * @see mbe_processAmbe3600x2400Framef for details.
  */
 MBE_API int mbe_processAmbe3600x2400Frame(short* aout_buf, mbe_process_result* result, const char ambe_fr[4][24],
                                           char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                          mbe_parms* prev_mp_enhanced, int uvquality);
+                                          mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a soft AMBE 3600x2400 frame into float PCM.
  * @param result Optional output status populated by decode and synthesis.
@@ -370,11 +366,11 @@ MBE_API int mbe_processAmbe3600x2400Frame(short* aout_buf, mbe_process_result* r
  */
 MBE_API int mbe_processAmbe3600x2400SoftFramef(float* aout_buf, mbe_process_result* result,
                                                const mbe_soft_bit ambe_fr[4][24], char ambe_d[49], mbe_parms* cur_mp,
-                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process a soft AMBE 3600x2400 frame into int16 PCM; see float variant for result semantics. */
 MBE_API int mbe_processAmbe3600x2400SoftFrame(short* aout_buf, mbe_process_result* result,
                                               const mbe_soft_bit ambe_fr[4][24], char ambe_d[49], mbe_parms* cur_mp,
-                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 
 /* Prototypes from ambe3600x2450.c */
 /** @brief Print AMBE 2450 parameter bits to stderr (debug). */
@@ -414,14 +410,13 @@ MBE_API int mbe_decodeAmbe3600x2450SoftFrame(const mbe_soft_bit ambe_fr[4][24], 
  * @param cur_mp   In/out: current frame parameters (may be enhanced).
  * @param prev_mp  In/out: previous frame parameters.
  * @param prev_mp_enhanced In/out: enhanced previous parameters for continuity.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processAmbe2450Dataf(float* aout_buf, mbe_process_result* result, const char ambe_d[49],
-                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process AMBE 2450 parameters into 16-bit PCM. */
 MBE_API int mbe_processAmbe2450Data(short* aout_buf, mbe_process_result* result, const char ambe_d[49],
-                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process AMBE 3600x2450 frame into float PCM.
  * @param aout_buf Output buffer of 160 float samples.
@@ -429,16 +424,15 @@ MBE_API int mbe_processAmbe2450Data(short* aout_buf, mbe_process_result* result,
  * @param ambe_fr  Input frame as 4x24 bitplanes.
  * @param ambe_d   Scratch/output parameter bits (49).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processAmbe3600x2450Framef(float* aout_buf, mbe_process_result* result, const char ambe_fr[4][24],
                                            char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                           mbe_parms* prev_mp_enhanced, int uvquality);
+                                           mbe_parms* prev_mp_enhanced);
 /** @brief Process AMBE 3600x2450 frame into 16-bit PCM. */
 MBE_API int mbe_processAmbe3600x2450Frame(short* aout_buf, mbe_process_result* result, const char ambe_fr[4][24],
                                           char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                          mbe_parms* prev_mp_enhanced, int uvquality);
+                                          mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a soft AMBE 3600x2450 frame into float PCM.
  * @param result Optional output status populated by decode and synthesis.
@@ -446,11 +440,11 @@ MBE_API int mbe_processAmbe3600x2450Frame(short* aout_buf, mbe_process_result* r
  */
 MBE_API int mbe_processAmbe3600x2450SoftFramef(float* aout_buf, mbe_process_result* result,
                                                const mbe_soft_bit ambe_fr[4][24], char ambe_d[49], mbe_parms* cur_mp,
-                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process a soft AMBE 3600x2450 frame into int16 PCM; see float variant for result semantics. */
 MBE_API int mbe_processAmbe3600x2450SoftFrame(short* aout_buf, mbe_process_result* result,
                                               const mbe_soft_bit ambe_fr[4][24], char ambe_d[49], mbe_parms* cur_mp,
-                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 
 /* Prototypes from imbe7200x4400.c */
 /** @brief Print IMBE 4400 parameter bits to stderr (debug). */
@@ -492,14 +486,13 @@ MBE_API int mbe_decodeImbe7200x4400SoftFrame(const mbe_soft_bit imbe_fr[8][23], 
  * @param cur_mp   In/out: current frame parameters (may be enhanced).
  * @param prev_mp  In/out: previous frame parameters.
  * @param prev_mp_enhanced In/out: enhanced previous parameters for continuity.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processImbe4400Dataf(float* aout_buf, mbe_process_result* result, const char imbe_d[88],
-                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                     mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process IMBE 4400 parameters into 16-bit PCM. */
 MBE_API int mbe_processImbe4400Data(short* aout_buf, mbe_process_result* result, const char imbe_d[88],
-                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                    mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process IMBE 7200x4400 frame into float PCM.
  * @param aout_buf Output buffer of 160 float samples.
@@ -507,16 +500,15 @@ MBE_API int mbe_processImbe4400Data(short* aout_buf, mbe_process_result* result,
  * @param imbe_fr  Input frame as 8x23 bitplanes.
  * @param imbe_d   Scratch/output parameter bits (88).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processImbe7200x4400Framef(float* aout_buf, mbe_process_result* result, const char imbe_fr[8][23],
                                            char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                           mbe_parms* prev_mp_enhanced, int uvquality);
+                                           mbe_parms* prev_mp_enhanced);
 /** @brief Process IMBE 7200x4400 frame into 16-bit PCM. */
 MBE_API int mbe_processImbe7200x4400Frame(short* aout_buf, mbe_process_result* result, const char imbe_fr[8][23],
                                           char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                          mbe_parms* prev_mp_enhanced, int uvquality);
+                                          mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a soft IMBE 7200x4400 frame into float PCM.
  * @param result Optional output status populated by decode and synthesis.
@@ -524,11 +516,11 @@ MBE_API int mbe_processImbe7200x4400Frame(short* aout_buf, mbe_process_result* r
  */
 MBE_API int mbe_processImbe7200x4400SoftFramef(float* aout_buf, mbe_process_result* result,
                                                const mbe_soft_bit imbe_fr[8][23], char imbe_d[88], mbe_parms* cur_mp,
-                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process a soft IMBE 7200x4400 frame into int16 PCM; see float variant for result semantics. */
 MBE_API int mbe_processImbe7200x4400SoftFrame(short* aout_buf, mbe_process_result* result,
                                               const mbe_soft_bit imbe_fr[8][23], char imbe_d[88], mbe_parms* cur_mp,
-                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 
 /* Prototypes from imbe7100x4400.c */
 /** @brief Print IMBE 7100x4400 parameter bits to stderr (debug). */
@@ -567,16 +559,15 @@ MBE_API int mbe_decodeImbe7100x4400SoftFrame(const mbe_soft_bit imbe_fr[7][24], 
  * @param imbe_fr  Input frame as 7x24 bitplanes.
  * @param imbe_d   Scratch/output parameter bits (88, converted to 7200 layout).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  * @return Total error count on success, or a negative `MBE_STATUS_*` code.
  */
 MBE_API int mbe_processImbe7100x4400Framef(float* aout_buf, mbe_process_result* result, const char imbe_fr[7][24],
                                            char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                           mbe_parms* prev_mp_enhanced, int uvquality);
+                                           mbe_parms* prev_mp_enhanced);
 /** @brief Process IMBE 7100x4400 frame into 16-bit PCM. */
 MBE_API int mbe_processImbe7100x4400Frame(short* aout_buf, mbe_process_result* result, const char imbe_fr[7][24],
                                           char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                                          mbe_parms* prev_mp_enhanced, int uvquality);
+                                          mbe_parms* prev_mp_enhanced);
 /**
  * @brief Process a soft IMBE 7100x4400 frame into float PCM.
  * @param result Optional output status populated by decode and synthesis.
@@ -584,11 +575,11 @@ MBE_API int mbe_processImbe7100x4400Frame(short* aout_buf, mbe_process_result* r
  */
 MBE_API int mbe_processImbe7100x4400SoftFramef(float* aout_buf, mbe_process_result* result,
                                                const mbe_soft_bit imbe_fr[7][24], char imbe_d[88], mbe_parms* cur_mp,
-                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                               mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 /** @brief Process a soft IMBE 7100x4400 frame into int16 PCM; see float variant for result semantics. */
 MBE_API int mbe_processImbe7100x4400SoftFrame(short* aout_buf, mbe_process_result* result,
                                               const mbe_soft_bit imbe_fr[7][24], char imbe_d[88], mbe_parms* cur_mp,
-                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality);
+                                              mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 
 /**
  * @brief Get a pointer to a static NUL-terminated version string.
@@ -657,9 +648,8 @@ MBE_API void mbe_synthesizeSilence(short* aout_buf);
  * @param aout_buf Output buffer of 160 float samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
-MBE_API void mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality);
+MBE_API void mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp);
 /**
  * @brief Synthesize one speech frame into 16-bit PCM.
  *
@@ -668,9 +658,8 @@ MBE_API void mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms
  * @param aout_buf Output buffer of 160 16-bit samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
-MBE_API void mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality);
+MBE_API void mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp);
 /**
  * @brief Convert 160 float samples to clipped/scaled 16-bit PCM.
  *

--- a/semgrep/mbelib-neo.yml
+++ b/semgrep/mbelib-neo.yml
@@ -24,6 +24,126 @@ rules:
       - pattern: posix_spawn(...)
       - pattern: posix_spawnp(...)
 
+  - id: mbelib-neo.no-production-assert
+    languages: [c, cpp]
+    severity: ERROR
+    message: >
+      Use explicit runtime validation or unreachable handling in production code instead of assert(), which can compile
+      out under NDEBUG.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /examples/**
+        - /bench/**
+        - /fuzz/**
+      exclude:
+        - /src/external/**
+    pattern: assert(...)
+
+  - id: mbelib-neo.no-weak-process-rng
+    languages: [c, cpp]
+    severity: ERROR
+    message: Do not use process-global rand()/srand(); use a purpose-specific RNG.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /examples/**
+        - /bench/**
+        - /fuzz/**
+      exclude:
+        - /src/external/**
+    pattern-either:
+      - pattern: rand(...)
+      - pattern: srand(...)
+
+  - id: mbelib-neo.no-atoi-family
+    languages: [c, cpp]
+    severity: ERROR
+    message: Use checked strto* parsing instead of atoi/atol/atoll/atof.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /examples/**
+        - /bench/**
+        - /fuzz/**
+      exclude:
+        - /src/external/**
+    pattern-either:
+      - pattern: atoi(...)
+      - pattern: atol(...)
+      - pattern: atoll(...)
+      - pattern: atof(...)
+      - pattern: std::atoi(...)
+      - pattern: std::atol(...)
+      - pattern: std::atoll(...)
+      - pattern: std::atof(...)
+
+  - id: mbelib-neo.no-unchecked-strto-endptr
+    languages: [c, cpp]
+    severity: ERROR
+    message: Check the strto* end pointer and range instead of passing NULL for endptr.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /examples/**
+        - /bench/**
+        - /fuzz/**
+      exclude:
+        - /src/external/**
+    pattern-either:
+      - pattern: strtol($S, NULL, $B)
+      - pattern: strtoul($S, NULL, $B)
+      - pattern: strtoll($S, NULL, $B)
+      - pattern: strtoull($S, NULL, $B)
+      - pattern: strtod($S, NULL)
+      - pattern: strtof($S, NULL)
+      - pattern: strtol($S, nullptr, $B)
+      - pattern: strtoul($S, nullptr, $B)
+      - pattern: strtoll($S, nullptr, $B)
+      - pattern: strtoull($S, nullptr, $B)
+      - pattern: strtod($S, nullptr)
+      - pattern: strtof($S, nullptr)
+      - pattern: std::strtol($S, NULL, $B)
+      - pattern: std::strtoul($S, NULL, $B)
+      - pattern: std::strtoll($S, NULL, $B)
+      - pattern: std::strtoull($S, NULL, $B)
+      - pattern: std::strtod($S, NULL)
+      - pattern: std::strtof($S, NULL)
+      - pattern: std::strtol($S, nullptr, $B)
+      - pattern: std::strtoul($S, nullptr, $B)
+      - pattern: std::strtoll($S, nullptr, $B)
+      - pattern: std::strtoull($S, nullptr, $B)
+      - pattern: std::strtod($S, nullptr)
+      - pattern: std::strtof($S, nullptr)
+
+  - id: mbelib-neo.no-raw-file-open
+    languages: [c, cpp]
+    severity: ERROR
+    message: Use an explicit project-approved file/path helper instead of raw file open/temp APIs in project-owned code.
+    paths:
+      include:
+        - /include/**
+        - /src/**
+        - /examples/**
+        - /bench/**
+        - /fuzz/**
+      exclude:
+        - /src/external/**
+    pattern-either:
+      - pattern: fopen(...)
+      - pattern: freopen(...)
+      - pattern: open(...)
+      - pattern: creat(...)
+      - pattern: tmpfile(...)
+      - pattern: tmpnam(...)
+      - pattern: mktemp(...)
+      - pattern: mkstemp(...)
+      - pattern: mkstemps(...)
+
   - id: mbelib-neo.no-direct-third-party-include
     languages: [c]
     severity: ERROR

--- a/src/ambe/ambe3600x2400.c
+++ b/src/ambe/ambe3600x2400.c
@@ -525,9 +525,6 @@ mbe_decodeAmbe2400Parms(const char* ambe_d, mbe_parms* cur_mp, mbe_parms* prev_m
     fprintf(stderr, "\n");
 #endif
 
-    // copy repeat from prev_mp
-    cur_mp->repeat = prev_mp->repeat;
-
     int b0 = ambe2400_decode_b0(ambe_d);
     int tone_frame = ambe2400_handle_tone_frame(ambe_d, cur_mp, b0, &L);
     if (tone_frame != 0) {
@@ -665,14 +662,12 @@ ambe2400_update_decode_state(int bad, int c0_errors, int total_errors, mbe_proce
                              const mbe_parms* prev_mp) {
     if (bad == 2) {
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_ERASURE);
-        cur_mp->repeat = 0;
         cur_mp->repeatCount = 0;
         mbe_setAmbeErasureParms_common(cur_mp, prev_mp);
         return;
     }
     if (bad == 3) {
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_TONE);
-        cur_mp->repeat = 0;
         cur_mp->repeatCount = 0;
         return;
     }
@@ -681,23 +676,21 @@ ambe2400_update_decode_state(int bad, int c0_errors, int total_errors, mbe_proce
     }
     if (total_errors > 3) {
         mbe_useLastMbeParms(cur_mp, prev_mp);
-        cur_mp->repeat++;
         cur_mp->repeatCount++;
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_REPEAT);
         return;
     }
 
-    cur_mp->repeat = 0;
     cur_mp->repeatCount = 0;
 }
 
 static void
 ambe2400_synthesize_voice(float* aout_buf, mbe_process_result* result, mbe_parms* cur_mp, mbe_parms* prev_mp,
-                          mbe_parms* prev_mp_enhanced, int uvquality) {
-    if (cur_mp->repeat <= 3) {
+                          mbe_parms* prev_mp_enhanced) {
+    if (cur_mp->repeatCount < MBE_MAX_FRAME_REPEATS) {
         mbe_moveMbeParms(cur_mp, prev_mp);
         float pre_enh_rm0 = mbe_spectralAmpEnhanceWithRm0(cur_mp);
-        mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, uvquality, pre_enh_rm0);
+        mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, pre_enh_rm0);
         mbe_moveMbeParms(cur_mp, prev_mp_enhanced);
         return;
     }
@@ -716,15 +709,14 @@ ambe2400_synthesize_erasure(float* aout_buf, const mbe_parms* cur_mp, mbe_parms*
 
 static void
 ambe2400_synthesize_frame(float* aout_buf, mbe_process_result* result, const char ambe_d[49], int bad, int c0_errors,
-                          int total_errors, mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                          int uvquality) {
+                          int total_errors, mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     if ((bad >= 7) && (bad <= 122) && (c0_errors < 2) && (total_errors < 3)) {
         mbe_synthesizeTonefdstar(aout_buf, ambe_d, cur_mp, bad);
         mbe_moveMbeParms(cur_mp, prev_mp);
         return;
     }
     if (bad == 0) {
-        ambe2400_synthesize_voice(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+        ambe2400_synthesize_voice(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced);
         return;
     }
     if (bad == 2) {
@@ -738,7 +730,7 @@ ambe2400_synthesize_frame(float* aout_buf, mbe_process_result* result, const cha
 
 int
 mbe_processAmbe2400Dataf(float* aout_buf, mbe_process_result* result, const char ambe_d[49], mbe_parms* cur_mp,
-                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int bad;
     int c0_errors;
@@ -763,20 +755,20 @@ mbe_processAmbe2400Dataf(float* aout_buf, mbe_process_result* result, const char
     }
 
     ambe2400_update_decode_state(bad, c0_errors, total_errors, result, cur_mp, prev_mp);
-    ambe2400_synthesize_frame(aout_buf, result, ambe_d, bad, c0_errors, total_errors, cur_mp, prev_mp, prev_mp_enhanced,
-                              uvquality);
+    ambe2400_synthesize_frame(aout_buf, result, ambe_d, bad, c0_errors, total_errors, cur_mp, prev_mp,
+                              prev_mp_enhanced);
     return result->total_errors;
 }
 
 int
 mbe_processAmbe2400Data(short* aout_buf, mbe_process_result* result, const char ambe_d[49], mbe_parms* cur_mp,
-                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe2400Dataf(float_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    ret = mbe_processAmbe2400Dataf(float_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -791,11 +783,10 @@ mbe_processAmbe2400Data(short* aout_buf, mbe_process_result* result, const char 
  * @param ambe_fr  Input frame as 4x24 bitplanes.
  * @param ambe_d   Scratch/output parameter bits (49).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processAmbe3600x2400Framef(float* aout_buf, mbe_process_result* result, const char ambe_fr[4][24], char ambe_d[49],
-                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -805,13 +796,13 @@ mbe_processAmbe3600x2400Framef(float* aout_buf, mbe_process_result* result, cons
     if (ret < 0) {
         return ret;
     }
-    return mbe_processAmbe2400Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processAmbe2400Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processAmbe3600x2400SoftFramef(float* aout_buf, mbe_process_result* result, const mbe_soft_bit ambe_fr[4][24],
-                                   char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                   int uvquality) {
+                                   char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                   mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -821,20 +812,18 @@ mbe_processAmbe3600x2400SoftFramef(float* aout_buf, mbe_process_result* result, 
     if (ret < 0) {
         return ret;
     }
-    return mbe_processAmbe2400Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processAmbe2400Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processAmbe3600x2400SoftFrame(short* aout_buf, mbe_process_result* result, const mbe_soft_bit ambe_fr[4][24],
-                                  char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                  int uvquality) {
+                                  char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe3600x2400SoftFramef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                             uvquality);
+    ret = mbe_processAmbe3600x2400SoftFramef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -848,15 +837,14 @@ mbe_processAmbe3600x2400SoftFrame(short* aout_buf, mbe_process_result* result, c
  */
 int
 mbe_processAmbe3600x2400Frame(short* aout_buf, mbe_process_result* result, const char ambe_fr[4][24], char ambe_d[49],
-                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
 
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe3600x2400Framef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                         uvquality);
+    ret = mbe_processAmbe3600x2400Framef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }

--- a/src/ambe/ambe3600x2450.c
+++ b/src/ambe/ambe3600x2450.c
@@ -583,9 +583,6 @@ mbe_decodeAmbe2450ParmsInternal(const char* ambe_d, mbe_parms* cur_mp, mbe_parms
     fprintf(stderr, "\n");
 #endif
 
-    // copy repeat from prev_mp
-    cur_mp->repeat = prev_mp->repeat;
-
     int special_frame = ambe2450_setup_frame_model(ambe_d, cur_mp, total_errors, &b0, &L, &f0, &silence);
     if (special_frame != 0) {
         return special_frame;
@@ -764,7 +761,6 @@ ambe2450_update_decode_state(int bad, int total_errors, int c0_errors, int c0_er
                              mbe_parms* cur_mp, const mbe_parms* prev_mp) {
     if (bad == 2) {
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_ERASURE);
-        cur_mp->repeat = 0;
         cur_mp->repeatCount = 0;
         /* JMBE erasure model: W120 defaults carried as previous frame state. */
         mbe_setAmbeErasureParms_common(cur_mp, prev_mp);
@@ -772,29 +768,26 @@ ambe2450_update_decode_state(int bad, int total_errors, int c0_errors, int c0_er
     }
     if (bad == 3 || bad == 7) {
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_TONE);
-        cur_mp->repeat = 0;
         cur_mp->repeatCount = 0;
         return;
     }
     if (ambe2450_repeat_required(total_errors, c0_errors, c0_errors_valid)) {
         mbe_useLastMbeParms(cur_mp, prev_mp);
-        cur_mp->repeat++;
         cur_mp->repeatCount++;
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_REPEAT);
         return;
     }
 
-    cur_mp->repeat = 0;
     cur_mp->repeatCount = 0;
 }
 
 static void
 ambe2450_synthesize_voice(float* aout_buf, mbe_process_result* result, mbe_parms* cur_mp, mbe_parms* prev_mp,
-                          mbe_parms* prev_mp_enhanced, int uvquality) {
-    if (cur_mp->repeat <= 3) {
+                          mbe_parms* prev_mp_enhanced) {
+    if (cur_mp->repeatCount < MBE_MAX_FRAME_REPEATS) {
         mbe_moveMbeParms(cur_mp, prev_mp);
         float pre_enh_rm0 = mbe_spectralAmpEnhanceWithRm0(cur_mp);
-        mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, uvquality, pre_enh_rm0);
+        mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, pre_enh_rm0);
         mbe_moveMbeParms(cur_mp, prev_mp_enhanced);
         return;
     }
@@ -806,7 +799,7 @@ ambe2450_synthesize_voice(float* aout_buf, mbe_process_result* result, mbe_parms
 
 static void
 ambe2450_synthesize_tone(float* aout_buf, const char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
-                         mbe_parms* prev_mp_enhanced, int uvquality) {
+                         mbe_parms* prev_mp_enhanced) {
     if (ambe2450_is_valid_tone_id(ambe_d)) {
         mbe_synthesizeTonef(aout_buf, ambe_d, cur_mp);
         return;
@@ -816,7 +809,7 @@ ambe2450_synthesize_tone(float* aout_buf, const char ambe_d[49], mbe_parms* cur_
 
         /* JMBE invalid-tone behavior reuses the prior VOICE model while still advancing synth state. */
         mbe_moveMbeParms(prev_mp_enhanced, &synth_mp);
-        mbe_synthesizeSpeechf(aout_buf, &synth_mp, prev_mp_enhanced, uvquality);
+        mbe_synthesizeSpeechf(aout_buf, &synth_mp, prev_mp_enhanced);
         mbe_moveMbeParms(&synth_mp, prev_mp_enhanced);
         return;
     }
@@ -836,13 +829,13 @@ ambe2450_synthesize_erasure(float* aout_buf, const mbe_parms* cur_mp, mbe_parms*
 
 static void
 ambe2450_synthesize_frame(float* aout_buf, mbe_process_result* result, const char ambe_d[49], int bad,
-                          mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                          mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     if (bad == 0) {
-        ambe2450_synthesize_voice(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+        ambe2450_synthesize_voice(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced);
         return;
     }
     if (bad == 7) {
-        ambe2450_synthesize_tone(aout_buf, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+        ambe2450_synthesize_tone(aout_buf, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
         return;
     }
     if (bad == 2) {
@@ -856,7 +849,7 @@ ambe2450_synthesize_frame(float* aout_buf, mbe_process_result* result, const cha
 
 static int
 mbe_processAmbe2450Dataf_internal(float* aout_buf, mbe_process_result* result, const char ambe_d[49], mbe_parms* cur_mp,
-                                  mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                                  mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     int bad;
     int c0_errors;
     int c0_errors_valid;
@@ -878,7 +871,7 @@ mbe_processAmbe2450Dataf_internal(float* aout_buf, mbe_process_result* result, c
     }
 
     ambe2450_update_decode_state(bad, total_errors, c0_errors, c0_errors_valid, result, cur_mp, prev_mp);
-    ambe2450_synthesize_frame(aout_buf, result, ambe_d, bad, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    ambe2450_synthesize_frame(aout_buf, result, ambe_d, bad, cur_mp, prev_mp, prev_mp_enhanced);
     return result ? result->total_errors : total_errors;
 }
 
@@ -890,29 +883,28 @@ mbe_processAmbe2450Dataf_internal(float* aout_buf, mbe_process_result* result, c
  * @param cur_mp   In/out: current frame parameters (may be enhanced).
  * @param prev_mp  In/out: previous frame parameters.
  * @param prev_mp_enhanced In/out: enhanced previous parameters for continuity.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processAmbe2450Dataf(float* aout_buf, mbe_process_result* result, const char ambe_d[49], mbe_parms* cur_mp,
-                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
 
     if (!result) {
         mbe_initProcessResult(&local_result);
         result = &local_result;
     }
-    return mbe_processAmbe2450Dataf_internal(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processAmbe2450Dataf_internal(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processAmbe2450Data(short* aout_buf, mbe_process_result* result, const char ambe_d[49], mbe_parms* cur_mp,
-                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe2450Dataf(float_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    ret = mbe_processAmbe2450Dataf(float_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -927,11 +919,10 @@ mbe_processAmbe2450Data(short* aout_buf, mbe_process_result* result, const char 
  * @param ambe_fr  Input frame as 4x24 bitplanes.
  * @param ambe_d   Scratch/output parameter bits (49).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processAmbe3600x2450Framef(float* aout_buf, mbe_process_result* result, const char ambe_fr[4][24], char ambe_d[49],
-                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -941,13 +932,13 @@ mbe_processAmbe3600x2450Framef(float* aout_buf, mbe_process_result* result, cons
     if (ret < 0) {
         return ret;
     }
-    return mbe_processAmbe2450Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processAmbe2450Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processAmbe3600x2450SoftFramef(float* aout_buf, mbe_process_result* result, const mbe_soft_bit ambe_fr[4][24],
-                                   char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                   int uvquality) {
+                                   char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                   mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -957,20 +948,18 @@ mbe_processAmbe3600x2450SoftFramef(float* aout_buf, mbe_process_result* result, 
     if (ret < 0) {
         return ret;
     }
-    return mbe_processAmbe2450Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processAmbe2450Dataf(aout_buf, result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processAmbe3600x2450SoftFrame(short* aout_buf, mbe_process_result* result, const mbe_soft_bit ambe_fr[4][24],
-                                  char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                  int uvquality) {
+                                  char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe3600x2450SoftFramef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                             uvquality);
+    ret = mbe_processAmbe3600x2450SoftFramef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -984,15 +973,14 @@ mbe_processAmbe3600x2450SoftFrame(short* aout_buf, mbe_process_result* result, c
  */
 int
 mbe_processAmbe3600x2450Frame(short* aout_buf, mbe_process_result* result, const char ambe_fr[4][24], char ambe_d[49],
-                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
 
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processAmbe3600x2450Framef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                         uvquality);
+    ret = mbe_processAmbe3600x2450Framef(float_buf, result, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }

--- a/src/ambe/ambe_common.c
+++ b/src/ambe/ambe_common.c
@@ -195,7 +195,7 @@ mbe_initAmbeParms_common(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_
     }
 
     prev_mp->swn = 0;
-    prev_mp->un = 0;
+    prev_mp->tonePhase = 0;
     /* JMBE AMBEFundamentalFrequency.W124: constructor uses (frequency * 2*PI), where frequency is PI/32. */
     prev_mp->w0 = (float)((M_PI / 32.0) * (2.0 * M_PI));
     prev_mp->L = 15;
@@ -210,8 +210,6 @@ mbe_initAmbeParms_common(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_
         /* JMBE previous-phase arrays start at 0.0f. */
         prev_mp->PSIl[l] = 0.0f;
     }
-
-    prev_mp->repeat = 0;
 
     prev_mp->localEnergy = MBE_DEFAULT_LOCAL_ENERGY;
     prev_mp->amplitudeThreshold = MBE_DEFAULT_AMPLITUDE_THRESHOLD;
@@ -239,7 +237,7 @@ mbe_setAmbeErasureParms_common(mbe_parms* mp, const mbe_parms* state_src) {
     const mbe_parms* continuity = state_src ? state_src : mp;
 
     mp->swn = 0;
-    mp->un = 0;
+    mp->tonePhase = 0;
     mp->w0 = 0.0f; /* JMBE AMBEFundamentalFrequency.W120..W123 */
     mp->L = 9;
     mp->K = 0;

--- a/src/core/mbelib.c
+++ b/src/core/mbelib.c
@@ -19,7 +19,7 @@
  * These functions and utilities are used internally by the library’s synthesis
  * implementation and are not part of the public API. Names and semantics may
  * change between releases. Where appropriate, helpers note the impact of
- * `MBELIB_ENABLE_SIMD` and `MBELIB_STRICT_ORDER` on determinism and ordering.
+ * `MBELIB_ENABLE_SIMD` on determinism and ordering.
  *
  * @{ 
  */
@@ -273,40 +273,48 @@ mbe_add_voiced_block4(float* restrict Ss, const float* restrict W, float gain, f
  * a second load/store of the output buffer when both voiced components are
  * active for the same harmonic.
  */
+typedef struct mbe_voiced_block_component {
+    const float* W;
+    float gain;
+    float* c;
+    float* s;
+    float sd;
+    float cd;
+} mbe_voiced_block_component;
+
 /** @internal @ingroup mbe_internal */
 static inline void
-mbe_add_voiced_dual_block4(float* restrict Ss, const float* restrict W_prev, float gain_prev, float* restrict c_prev,
-                           float* restrict s_prev, float sd_prev, float cd_prev, const float* restrict W_cur,
-                           float gain_cur, float* restrict c_cur, float* restrict s_cur, float sd_cur, float cd_cur) {
+mbe_add_voiced_dual_block4(float* restrict Ss, const mbe_voiced_block_component* restrict prev,
+                           const mbe_voiced_block_component* restrict cur) {
     float prev_cblk[4];
     float cur_cblk[4];
 
-    mbe_fill_voiced_cos_block4(prev_cblk, c_prev, s_prev, sd_prev, cd_prev);
-    mbe_fill_voiced_cos_block4(cur_cblk, c_cur, s_cur, sd_cur, cd_cur);
+    mbe_fill_voiced_cos_block4(prev_cblk, prev->c, prev->s, prev->sd, prev->cd);
+    mbe_fill_voiced_cos_block4(cur_cblk, cur->c, cur->s, cur->sd, cur->cd);
 
 #if defined(MBELIB_ENABLE_SIMD) && defined(MBE_SIMD_TARGET_SSE2)
     __m128 vS = _mm_loadu_ps(Ss);
-    __m128 vPrev = _mm_mul_ps(_mm_mul_ps(_mm_loadu_ps(prev_cblk), _mm_loadu_ps(W_prev)), _mm_set1_ps(gain_prev));
-    __m128 vCur = _mm_mul_ps(_mm_mul_ps(_mm_loadu_ps(cur_cblk), _mm_loadu_ps(W_cur)), _mm_set1_ps(gain_cur));
+    __m128 vPrev = _mm_mul_ps(_mm_mul_ps(_mm_loadu_ps(prev_cblk), _mm_loadu_ps(prev->W)), _mm_set1_ps(prev->gain));
+    __m128 vCur = _mm_mul_ps(_mm_mul_ps(_mm_loadu_ps(cur_cblk), _mm_loadu_ps(cur->W)), _mm_set1_ps(cur->gain));
     vS = _mm_add_ps(vS, vPrev);
     vS = _mm_add_ps(vS, vCur);
     _mm_storeu_ps(Ss, vS);
 #elif defined(MBELIB_ENABLE_SIMD) && defined(MBE_SIMD_TARGET_NEON)
     float32x4_t vS = vld1q_f32(Ss);
-    float32x4_t vPrev = vmulq_f32(vmulq_f32(vld1q_f32(prev_cblk), vld1q_f32(W_prev)), vdupq_n_f32(gain_prev));
-    float32x4_t vCur = vmulq_f32(vmulq_f32(vld1q_f32(cur_cblk), vld1q_f32(W_cur)), vdupq_n_f32(gain_cur));
+    float32x4_t vPrev = vmulq_f32(vmulq_f32(vld1q_f32(prev_cblk), vld1q_f32(prev->W)), vdupq_n_f32(prev->gain));
+    float32x4_t vCur = vmulq_f32(vmulq_f32(vld1q_f32(cur_cblk), vld1q_f32(cur->W)), vdupq_n_f32(cur->gain));
     vS = vaddq_f32(vS, vPrev);
     vS = vaddq_f32(vS, vCur);
     vst1q_f32(Ss, vS);
 #else
-    Ss[0] += gain_prev * W_prev[0] * prev_cblk[0];
-    Ss[1] += gain_prev * W_prev[1] * prev_cblk[1];
-    Ss[2] += gain_prev * W_prev[2] * prev_cblk[2];
-    Ss[3] += gain_prev * W_prev[3] * prev_cblk[3];
-    Ss[0] += gain_cur * W_cur[0] * cur_cblk[0];
-    Ss[1] += gain_cur * W_cur[1] * cur_cblk[1];
-    Ss[2] += gain_cur * W_cur[2] * cur_cblk[2];
-    Ss[3] += gain_cur * W_cur[3] * cur_cblk[3];
+    Ss[0] += prev->gain * prev->W[0] * prev_cblk[0];
+    Ss[1] += prev->gain * prev->W[1] * prev_cblk[1];
+    Ss[2] += prev->gain * prev->W[2] * prev_cblk[2];
+    Ss[3] += prev->gain * prev->W[3] * prev_cblk[3];
+    Ss[0] += cur->gain * cur->W[0] * cur_cblk[0];
+    Ss[1] += cur->gain * cur->W[1] * cur_cblk[1];
+    Ss[2] += cur->gain * cur->W[2] * cur_cblk[2];
+    Ss[3] += cur->gain * cur->W[3] * cur_cblk[3];
 #endif
 }
 
@@ -365,7 +373,7 @@ mbe_initMbeParms(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhan
 
     int l;
     prev_mp->swn = 0;
-    prev_mp->un = 0;
+    prev_mp->tonePhase = 0;
     /* Match JMBE IMBEModelParameters default (IMBEFundamentalFrequency.DEFAULT, index 134). */
     prev_mp->w0 = (float)((4.0 * M_PI) / (134.0 + 39.5));
     prev_mp->L = (int)(0.9254 * (int)((M_PI / prev_mp->w0) + 0.25));
@@ -379,8 +387,6 @@ mbe_initMbeParms(mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhan
         /* JMBE previous-phase arrays start at 0.0f. */
         prev_mp->PSIl[l] = 0.0f;
     }
-    prev_mp->repeat = 0;
-
     /* Initialize adaptive smoothing state */
     prev_mp->localEnergy = MBE_DEFAULT_LOCAL_ENERGY;
     prev_mp->amplitudeThreshold = MBE_DEFAULT_AMPLITUDE_THRESHOLD;
@@ -710,7 +716,7 @@ mbe_renderTonef(float* aout_buf, mbe_parms* cur_mp, float freq1, float freq2, in
     const uint32_t step1 = mbe_tonePhaseStep((double)freq1);
     const uint32_t step2 = dual_tone ? mbe_tonePhaseStep((double)freq2) : 0u;
     uint32_t phase1 = (uint32_t)cur_mp->swn;
-    uint32_t phase2 = (uint32_t)cur_mp->un;
+    uint32_t phase2 = (uint32_t)cur_mp->tonePhase;
 
     for (int n = 0; n < 160; n++) {
         phase1 += step1;
@@ -726,7 +732,7 @@ mbe_renderTonef(float* aout_buf, mbe_parms* cur_mp, float freq1, float freq2, in
     }
 
     cur_mp->swn = (int)phase1;
-    cur_mp->un = (int)phase2;
+    cur_mp->tonePhase = phase2;
 }
 #endif
 
@@ -882,7 +888,6 @@ mbe_synthesizeSilence(short* aout_buf) {
  * @param aout_buf Output buffer of 160 float samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 /* JMBE-compatible white noise scalar for phase calculation: 2*PI / 53125 */
 #define MBE_WHITE_NOISE_SCALAR (2.0f * (float)M_PI / 53125.0f)
@@ -981,8 +986,10 @@ mbe_render_voiced_windowed(float* aout_buf, const mbe_parms* cur_mp, const mbe_p
         mbe_sincosf(cur_mp->PHIl[l] - (cw0l * (float)N), &s_cur, &c_cur);
 
         for (int n = 0; n < N; n += 4) {
-            mbe_add_voiced_dual_block4(Ss, Ws + n + N, gain_prev, &c_prev, &s_prev, sd_prev, cd_prev, Ws + n, gain_cur,
-                                       &c_cur, &s_cur, sd_cur, cd_cur);
+            const mbe_voiced_block_component prev_component = {Ws + n + N, gain_prev, &c_prev,
+                                                               &s_prev,    sd_prev,   cd_prev};
+            const mbe_voiced_block_component cur_component = {Ws + n, gain_cur, &c_cur, &s_cur, sd_cur, cd_cur};
+            mbe_add_voiced_dual_block4(Ss, &prev_component, &cur_component);
             Ss += 4;
         }
     } else if (prev_voiced) {
@@ -1033,7 +1040,7 @@ mbe_render_voiced_speech(float* aout_buf, const mbe_parms* cur_mp, const mbe_par
 }
 
 static void
-mbe_synthesizeSpeechCore(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality, int has_pre_enh_rm0,
+mbe_synthesizeSpeechCore(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int has_pre_enh_rm0,
                          float pre_enh_rm0) {
 
     const int N = 160;
@@ -1046,9 +1053,6 @@ mbe_synthesizeSpeechCore(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp,
         mbe_synthesizeSilencef(aout_buf);
         return;
     }
-
-    /* Silence unused parameter warning - uvquality is kept for API compatibility */
-    (void)uvquality;
 
     /* Apply adaptive smoothing (Algorithms #111-116) before muting checks.
      * JMBE computes/update smoothing state during parameter preparation even
@@ -1101,13 +1105,13 @@ mbe_synthesizeSpeechCore(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp,
 }
 
 void
-mbe_synthesizeSpeechWithPreEnhRm0f(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality, float rm0) {
-    mbe_synthesizeSpeechCore(aout_buf, cur_mp, prev_mp, uvquality, 1, rm0);
+mbe_synthesizeSpeechWithPreEnhRm0f(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, float rm0) {
+    mbe_synthesizeSpeechCore(aout_buf, cur_mp, prev_mp, 1, rm0);
 }
 
 void
-mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality) {
-    mbe_synthesizeSpeechCore(aout_buf, cur_mp, prev_mp, uvquality, 0, 0.0f);
+mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp) {
+    mbe_synthesizeSpeechCore(aout_buf, cur_mp, prev_mp, 0, 0.0f);
 }
 
 /**
@@ -1115,16 +1119,15 @@ mbe_synthesizeSpeechf(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, in
  * @param aout_buf Output buffer of 160 16-bit samples.
  * @param cur_mp   Current parameter set.
  * @param prev_mp  Previous parameter set.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 void
-mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality) {
+mbe_synthesizeSpeech(short* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp) {
     float float_buf[160];
 
     if (MBE_UNLIKELY(!aout_buf)) {
         return;
     }
-    mbe_synthesizeSpeechf(float_buf, cur_mp, prev_mp, uvquality);
+    mbe_synthesizeSpeechf(float_buf, cur_mp, prev_mp);
     mbe_floattoshort(float_buf, aout_buf);
 }
 

--- a/src/imbe/imbe7100x4400.c
+++ b/src/imbe/imbe7100x4400.c
@@ -16,10 +16,10 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "imbe4400_internal.h"
+#include "mbe_bitpack.h"
 #include "mbe_result.h"
 #include "mbelib-neo/mbelib.h"
 
@@ -294,20 +294,13 @@ mbe_demodulateImbe7100x4400Data(char imbe[7][24]) {
     int i, j, k;
     unsigned short pr[115];
     unsigned short seed;
-    char tmpstr[24];
     int ret = mbe_validate_bits((const char*)imbe, (size_t)7u * 24u);
     if (ret < 0) {
         return ret;
     }
 
     // create pseudo-random modulator
-    j = 0;
-    tmpstr[7] = 0;
-    for (i = 18; i > 11; i--) {
-        tmpstr[j] = (imbe[0][i] + 48);
-        j++;
-    }
-    seed = strtol(tmpstr, NULL, 2);
+    seed = (unsigned short)mbe_bits_descending_to_int(imbe[0], 18, 12);
     pr[0] = (16 * seed);
     for (i = 1; i < 101; i++) {
         pr[i] = (173 * pr[i - 1]) + 13849 - (65536 * (((173 * pr[i - 1]) + 13849) / 65536));
@@ -388,7 +381,6 @@ int
 mbe_convertImbe7100to7200(char* imbe_d) {
 
     int i, j, k, K, L, b0;
-    char tmpstr[9];
     char tmp_imbe[88];
     float w0;
     int ret = mbe_validate_bits(imbe_d, 88u);
@@ -397,16 +389,8 @@ mbe_convertImbe7100to7200(char* imbe_d) {
     }
 
     // decode fundamental frequency w0 from b0
-    tmpstr[8] = 0;
-    tmpstr[0] = imbe_d[1] + 48;
-    tmpstr[1] = imbe_d[2] + 48;
-    tmpstr[2] = imbe_d[3] + 48;
-    tmpstr[3] = imbe_d[4] + 48;
-    tmpstr[4] = imbe_d[5] + 48;
-    tmpstr[5] = imbe_d[6] + 48;
-    tmpstr[6] = imbe_d[86] + 48;
-    tmpstr[7] = imbe_d[87] + 48;
-    b0 = strtol(tmpstr, NULL, 2);
+    static const unsigned b0_indices[] = {1u, 2u, 3u, 4u, 5u, 6u, 86u, 87u};
+    b0 = mbe_bits_by_index_to_int(imbe_d, b0_indices, sizeof(b0_indices) / sizeof(b0_indices[0]));
     w0 = ((float)(4 * M_PI) / (float)((float)b0 + 39.5));
 
     // decode L from w0
@@ -538,11 +522,10 @@ mbe_decodeImbe7100x4400SoftFrame(const mbe_soft_bit imbe_fr[7][24], char imbe_d[
  * @param imbe_fr  Input frame as 7x24 bitplanes.
  * @param imbe_d   Scratch/output parameter bits (88).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processImbe7100x4400Framef(float* aout_buf, mbe_process_result* result, const char imbe_fr[7][24], char imbe_d[88],
-                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -552,13 +535,13 @@ mbe_processImbe7100x4400Framef(float* aout_buf, mbe_process_result* result, cons
     if (ret < 0) {
         return ret;
     }
-    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processImbe7100x4400SoftFramef(float* aout_buf, mbe_process_result* result, const mbe_soft_bit imbe_fr[7][24],
-                                   char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                   int uvquality) {
+                                   char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                   mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -568,20 +551,18 @@ mbe_processImbe7100x4400SoftFramef(float* aout_buf, mbe_process_result* result, 
     if (ret < 0) {
         return ret;
     }
-    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processImbe7100x4400SoftFrame(short* aout_buf, mbe_process_result* result, const mbe_soft_bit imbe_fr[7][24],
-                                  char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                  int uvquality) {
+                                  char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processImbe7100x4400SoftFramef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                             uvquality);
+    ret = mbe_processImbe7100x4400SoftFramef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -595,15 +576,14 @@ mbe_processImbe7100x4400SoftFrame(short* aout_buf, mbe_process_result* result, c
  */
 int
 mbe_processImbe7100x4400Frame(short* aout_buf, mbe_process_result* result, const char imbe_fr[7][24], char imbe_d[88],
-                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
 
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processImbe7100x4400Framef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                         uvquality);
+    ret = mbe_processImbe7100x4400Framef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }

--- a/src/imbe/imbe7200x4400.c
+++ b/src/imbe/imbe7200x4400.c
@@ -16,12 +16,12 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "imbe4400_internal.h"
 #include "imbe7200x4400_const.h"
 #include "mbe_adaptive.h"
+#include "mbe_bitpack.h"
 #include "mbe_compiler.h"
 #include "mbe_result.h"
 #include "mbe_validation.h"
@@ -60,7 +60,7 @@ imbe_reset_headroom_defaults(mbe_parms* mp) {
     }
 
     mp->swn = 0;
-    mp->un = 0;
+    mp->tonePhase = 0;
     /* Match JMBE IMBEModelParameters.copy() overflow path:
      * setMBEFundamentalFrequency(IMBEFundamentalFrequency.DEFAULT), then rebuild model arrays. */
     mp->w0 = (float)((4.0 * M_PI) / (134.0 + 39.5));
@@ -74,7 +74,6 @@ imbe_reset_headroom_defaults(mbe_parms* mp) {
         mp->log2Ml[l] = 0.0f;
     }
 
-    mp->repeat = 0;
     mp->repeatCount = 0;
     mp->localEnergy = 75000.0f;
     mp->amplitudeThreshold = 20480;
@@ -117,18 +116,8 @@ imbe_get_dct_cache(void) {
 
 static int
 imbe_decode_fundamental(const char* imbe_d, mbe_parms* cur_mp, int* out_L9) {
-    char tmpstr[13];
-    tmpstr[8] = 0;
-    tmpstr[0] = imbe_d[0] + 48;
-    tmpstr[1] = imbe_d[1] + 48;
-    tmpstr[2] = imbe_d[2] + 48;
-    tmpstr[3] = imbe_d[3] + 48;
-    tmpstr[4] = imbe_d[4] + 48;
-    tmpstr[5] = imbe_d[5] + 48;
-    tmpstr[6] = imbe_d[85] + 48;
-    tmpstr[7] = imbe_d[86] + 48;
-
-    int b0 = strtol(tmpstr, NULL, 2);
+    static const unsigned b0_indices[] = {0u, 1u, 2u, 3u, 4u, 5u, 85u, 86u};
+    int b0 = mbe_bits_by_index_to_int(imbe_d, b0_indices, sizeof(b0_indices) / sizeof(b0_indices[0]));
     if (b0 > 207) {
 #ifdef IMBE_DEBUG
         if ((b0 >= 216) && (b0 <= 219)) {
@@ -200,35 +189,19 @@ imbe_decode_voicing(mbe_parms* cur_mp, char bb[58][12]) {
 
 static void
 imbe_decode_gains(char bb[58][12], int L9, float Gm[7]) {
-    char tmpstr[13];
-    tmpstr[6] = 0;
-    tmpstr[0] = bb[2][5] + 48;
-    tmpstr[1] = bb[2][4] + 48;
-    tmpstr[2] = bb[2][3] + 48;
-    tmpstr[3] = bb[2][2] + 48;
-    tmpstr[4] = bb[2][1] + 48;
-    tmpstr[5] = bb[2][0] + 48;
-
-    int b2 = strtol(tmpstr, NULL, 2);
+    int b2 = mbe_bits_descending_to_int(bb[2], 5, 0);
     Gm[1] = B2[b2];
 #ifdef IMBE_DEBUG
-    fprintf(stderr, "G1: %e, %s, %i\n", Gm[1], tmpstr, b2);
-    fprintf(stderr, "tmpstr: %s b2: %i g1: %e\n", tmpstr, b2, Gm[1]);
+    fprintf(stderr, "b2: %i g1: %e\n", b2, Gm[1]);
 #endif
 
     const float* ba1 = ba[L9][0];
     const float* ba2 = ba1 + 1;
     for (int i = 2; i < 7; i++) {
-        tmpstr[(int)*ba1] = 0;
-        int k = 0;
-        for (int j = ((int)*ba1 - 1); j >= 0; j--) {
-            tmpstr[k] = bb[i + 1][j] + 48;
-            k++;
-        }
-        int bm = strtol(tmpstr, NULL, 2);
+        int bm = mbe_bits_descending_to_int(bb[i + 1], (int)*ba1 - 1, 0);
         Gm[i] = (*ba2 * ((float)bm - exp2f((*ba1) - 1.0f) + 0.5f));
 #ifdef IMBE_DEBUG
-        fprintf(stderr, "G%i: %e, %s, %i, ba1: %e, ba2: %e\n", i, Gm[i], tmpstr, bm, *ba1, *ba2);
+        fprintf(stderr, "G%i: %e, %i, ba1: %e, ba2: %e\n", i, Gm[i], bm, *ba1, *ba2);
 #endif
         ba1 += 2;
         ba2 += 2;
@@ -260,19 +233,14 @@ imbe_compute_ri(const float Gm[7], float Ri[7]) {
 static void
 imbe_decode_hoc_coefficients(char bb[58][12], int L9, const float Ri[7], float Cik[7][11]) {
     int m = 8;
-    char tmpstr[13];
     for (int i = 1; i <= 6; i++) {
         Cik[i][1] = Ri[i];
         for (int k = 2; k <= ImbeJi[L9][i - 1]; k++) {
             int Bm = hoba[L9][m - 8];
-            for (int b = 0; b < Bm; b++) {
-                tmpstr[b] = bb[m][(Bm - b) - 1] + 48;
-            }
             if (Bm <= 0) {
                 Cik[i][k] = 0;
             } else {
-                tmpstr[Bm] = 0;
-                int bm = strtol(tmpstr, NULL, 2);
+                int bm = mbe_bits_descending_to_int(bb[m], Bm - 1, 0);
                 Cik[i][k] = ((quantstep[Bm - 1] * standdev[k - 2]) * (((float)bm - exp2f((float)Bm - 1.0f)) + 0.5f));
             }
             m++;
@@ -634,9 +602,6 @@ mbe_decodeImbe4400Parms(const char* imbe_d, mbe_parms* cur_mp, mbe_parms* prev_m
         return ret;
     }
 
-    // copy repeat from prev_mp
-    cur_mp->repeat = prev_mp->repeat;
-
     if (imbe_decode_fundamental(imbe_d, cur_mp, &L9) != 0) {
         return (1);
     }
@@ -674,7 +639,6 @@ mbe_demodulateImbe7200x4400Data(char imbe[8][23]) {
     int i, j, k;
     unsigned short pr[115];
     unsigned short foo;
-    char tmpstr[24];
 
     int ret = mbe_validate_bits((const char*)imbe, (size_t)8u * 23u);
     if (ret < 0) {
@@ -682,13 +646,7 @@ mbe_demodulateImbe7200x4400Data(char imbe[8][23]) {
     }
 
     // create pseudo-random modulator
-    j = 0;
-    tmpstr[12] = 0;
-    for (i = 22; i >= 11; i--) {
-        tmpstr[j] = (imbe[0][i] + 48);
-        j++;
-    }
-    foo = strtol(tmpstr, NULL, 2);
+    foo = (unsigned short)mbe_bits_descending_to_int(imbe[0], 22, 11);
     pr[0] = (16 * foo);
     for (i = 1; i < 115; i++) {
         pr[i] = (173 * pr[i - 1]) + 13849 - (65536 * (((173 * pr[i - 1]) + 13849) / 65536));
@@ -867,7 +825,6 @@ static void
 imbe4400_apply_repeat_decision(int repeat_required, mbe_process_result* result, mbe_parms* cur_mp,
                                const mbe_parms* prev_mp) {
     if (!repeat_required) {
-        cur_mp->repeat = 0;
         cur_mp->repeatCount = 0;
         return;
     }
@@ -877,7 +834,6 @@ imbe4400_apply_repeat_decision(int repeat_required, mbe_process_result* result, 
         imbe_reset_headroom_defaults(cur_mp);
     } else {
         mbe_useLastMbeParms(cur_mp, prev_mp);
-        cur_mp->repeat++;
         cur_mp->repeatCount++;
     }
     mbe_result_set_flag(result, MBE_PROCESS_FLAG_REPEAT);
@@ -885,12 +841,12 @@ imbe4400_apply_repeat_decision(int repeat_required, mbe_process_result* result, 
 
 static void
 imbe4400_synthesize_frame(float* aout_buf, mbe_process_result* result, mbe_parms* cur_mp, mbe_parms* prev_mp,
-                          mbe_parms* prev_mp_enhanced, int uvquality) {
+                          mbe_parms* prev_mp_enhanced) {
     int frame_muted = mbe_isMaxFrameRepeat(cur_mp) || mbe_requiresMuting(cur_mp);
 
     mbe_moveMbeParms(cur_mp, prev_mp);
     float pre_enh_rm0 = mbe_spectralAmpEnhanceWithRm0(cur_mp);
-    mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, uvquality, pre_enh_rm0);
+    mbe_synthesizeSpeechWithPreEnhRm0f(aout_buf, cur_mp, prev_mp_enhanced, pre_enh_rm0);
 
     if (frame_muted) {
         mbe_result_set_flag(result, MBE_PROCESS_FLAG_MUTE);
@@ -901,7 +857,7 @@ imbe4400_synthesize_frame(float* aout_buf, mbe_process_result* result, mbe_parms
 
 int
 mbe_processImbe4400Dataf_internal(float* aout_buf, mbe_process_result* result, const char imbe_d[88], mbe_parms* cur_mp,
-                                  mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                                  mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     int bad;
     int repeat_required;
     float repeat_threshold;
@@ -927,7 +883,7 @@ mbe_processImbe4400Dataf_internal(float* aout_buf, mbe_process_result* result, c
     repeat_required = imbe4400_repeat_required(bad, total_errors, c0_errors, c0_errors_valid, repeat_threshold);
 
     imbe4400_apply_repeat_decision(repeat_required, result, cur_mp, prev_mp);
-    imbe4400_synthesize_frame(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    imbe4400_synthesize_frame(aout_buf, result, cur_mp, prev_mp, prev_mp_enhanced);
     return result ? result->total_errors : total_errors;
 }
 
@@ -939,29 +895,28 @@ mbe_processImbe4400Dataf_internal(float* aout_buf, mbe_process_result* result, c
  * @param cur_mp   In/out: current frame parameters (may be enhanced).
  * @param prev_mp  In/out: previous frame parameters.
  * @param prev_mp_enhanced In/out: enhanced previous parameters for continuity.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processImbe4400Dataf(float* aout_buf, mbe_process_result* result, const char imbe_d[88], mbe_parms* cur_mp,
-                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                         mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
 
     if (!result) {
         mbe_initProcessResult(&local_result);
         result = &local_result;
     }
-    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processImbe4400Dataf_internal(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processImbe4400Data(short* aout_buf, mbe_process_result* result, const char imbe_d[88], mbe_parms* cur_mp,
-                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                        mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processImbe4400Dataf(float_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    ret = mbe_processImbe4400Dataf(float_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -976,11 +931,10 @@ mbe_processImbe4400Data(short* aout_buf, mbe_process_result* result, const char 
  * @param imbe_fr  Input frame as 8x23 bitplanes.
  * @param imbe_d   Scratch/output parameter bits (88).
  * @param cur_mp,prev_mp,prev_mp_enhanced Parameter state as per Dataf variant.
- * @param uvquality Legacy quality knob (currently ignored; kept for API compatibility).
  */
 int
 mbe_processImbe7200x4400Framef(float* aout_buf, mbe_process_result* result, const char imbe_fr[8][23], char imbe_d[88],
-                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                               mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -990,13 +944,13 @@ mbe_processImbe7200x4400Framef(float* aout_buf, mbe_process_result* result, cons
     if (ret < 0) {
         return ret;
     }
-    return mbe_processImbe4400Dataf(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processImbe4400Dataf(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processImbe7200x4400SoftFramef(float* aout_buf, mbe_process_result* result, const mbe_soft_bit imbe_fr[8][23],
-                                   char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                   int uvquality) {
+                                   char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                   mbe_parms* prev_mp_enhanced) {
     mbe_process_result local_result;
     int ret;
     if (!result) {
@@ -1006,20 +960,18 @@ mbe_processImbe7200x4400SoftFramef(float* aout_buf, mbe_process_result* result, 
     if (ret < 0) {
         return ret;
     }
-    return mbe_processImbe4400Dataf(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+    return mbe_processImbe4400Dataf(aout_buf, result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
 }
 
 int
 mbe_processImbe7200x4400SoftFrame(short* aout_buf, mbe_process_result* result, const mbe_soft_bit imbe_fr[8][23],
-                                  char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                  int uvquality) {
+                                  char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processImbe7200x4400SoftFramef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                             uvquality);
+    ret = mbe_processImbe7200x4400SoftFramef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }
@@ -1033,15 +985,14 @@ mbe_processImbe7200x4400SoftFrame(short* aout_buf, mbe_process_result* result, c
  */
 int
 mbe_processImbe7200x4400Frame(short* aout_buf, mbe_process_result* result, const char imbe_fr[8][23], char imbe_d[88],
-                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced, int uvquality) {
+                              mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced) {
 
     float float_buf[160];
     int ret;
     if (!aout_buf) {
         return MBE_STATUS_INVALID_ARGUMENT;
     }
-    ret = mbe_processImbe7200x4400Framef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced,
-                                         uvquality);
+    ret = mbe_processImbe7200x4400Framef(float_buf, result, imbe_fr, imbe_d, cur_mp, prev_mp, prev_mp_enhanced);
     if (ret < 0) {
         return ret;
     }

--- a/src/internal/imbe4400_internal.h
+++ b/src/internal/imbe4400_internal.h
@@ -9,7 +9,6 @@
 #include "mbelib-neo/mbelib.h"
 
 int mbe_processImbe4400Dataf_internal(float* aout_buf, mbe_process_result* result, const char imbe_d[88],
-                                      mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                                      int uvquality);
+                                      mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced);
 
 #endif /* MBELIB_NEO_INTERNAL_IMBE4400_INTERNAL_H */

--- a/src/internal/mbe_adaptive.h
+++ b/src/internal/mbe_adaptive.h
@@ -76,11 +76,9 @@ float mbe_spectralAmpEnhanceWithRm0(mbe_parms* cur_mp);
  * @param aout_buf Output buffer of 160 float samples.
  * @param cur_mp Current frame parameters.
  * @param prev_mp Previous enhanced frame parameters.
- * @param uvquality Unvoiced synthesis quality setting.
  * @param rm0 Sum of squared pre-enhancement amplitudes.
  */
-void mbe_synthesizeSpeechWithPreEnhRm0f(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, int uvquality,
-                                        float rm0);
+void mbe_synthesizeSpeechWithPreEnhRm0f(float* aout_buf, mbe_parms* cur_mp, mbe_parms* prev_mp, float rm0);
 
 /**
  * @brief Seed the comfort-noise RNG used by mbe_synthesizeComfortNoisef().

--- a/src/internal/mbe_bitpack.h
+++ b/src/internal/mbe_bitpack.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef MBELIB_NEO_INTERNAL_MBE_BITPACK_H
+#define MBELIB_NEO_INTERNAL_MBE_BITPACK_H
+
+#include <stddef.h>
+
+static inline int
+mbe_bits_by_index_to_int(const char* bits, const unsigned* indices, size_t count) {
+    int value = 0;
+    for (size_t i = 0u; i < count; ++i) {
+        value = (value << 1) | (int)(bits[indices[i]] & 1);
+    }
+    return value;
+}
+
+static inline int
+mbe_bits_descending_to_int(const char* bits, int high, int low) {
+    int value = 0;
+    for (int i = high; i >= low; --i) {
+        value = (value << 1) | (int)(bits[i] & 1);
+    }
+    return value;
+}
+
+#endif /* MBELIB_NEO_INTERNAL_MBE_BITPACK_H */

--- a/src/internal/mbe_result.h
+++ b/src/internal/mbe_result.h
@@ -11,6 +11,9 @@
 #include "mbelib-neo/mbelib.h"
 
 #define MBE_RESULT_CONTEXT_FLAGS (MBE_PROCESS_FLAG_SOFT_INPUT | MBE_PROCESS_FLAG_C0_VALID | MBE_PROCESS_FLAG_C4_VALID)
+#define MBE_RESULT_STATUS_FLAGS                                                                                        \
+    (MBE_PROCESS_FLAG_TONE | MBE_PROCESS_FLAG_ERASURE | MBE_PROCESS_FLAG_REPEAT | MBE_PROCESS_FLAG_MUTE)
+#define MBE_RESULT_ALL_FLAGS (MBE_RESULT_CONTEXT_FLAGS | MBE_RESULT_STATUS_FLAGS)
 
 static inline int
 mbe_validate_bits(const char* bits, size_t count) {
@@ -61,7 +64,7 @@ mbe_result_total_errors_are_consistent(const mbe_process_result* result, int tot
     const int c0_valid = (result->flags & MBE_PROCESS_FLAG_C0_VALID) != 0u;
     const int c4_valid = (result->flags & MBE_PROCESS_FLAG_C4_VALID) != 0u;
 
-    return (component_total == 0 || total >= component_total) && (!c0_valid || total >= result->c0_errors)
+    return (component_total == 0 || total == component_total) && (!c0_valid || total >= result->c0_errors)
            && (!c4_valid || total >= result->c4_errors);
 }
 
@@ -76,6 +79,9 @@ mbe_result_resolve_total_errors(const mbe_process_result* result, int* total_err
     if (!result) {
         *total_errors = 0;
         return 0;
+    }
+    if ((result->flags & ~MBE_RESULT_ALL_FLAGS) != 0u) {
+        return MBE_STATUS_INVALID_ARGUMENT;
     }
     if (mbe_result_validate_component_errors(result, &component_total) < 0) {
         return MBE_STATUS_INVALID_ARGUMENT;

--- a/tests/test_frame_paths.c
+++ b/tests/test_frame_paths.c
@@ -86,7 +86,7 @@ test_ambe2400_frame_paths(void) {
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
     data_result = hard_result;
-    ret = mbe_processAmbe2400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe2400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &data_result);
     assert_float_pcm_sane(out_f);
@@ -95,25 +95,25 @@ test_ambe2400_frame_paths(void) {
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
     data_result = hard_result;
-    ret = mbe_processAmbe2400Data(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe2400Data(out_s, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &data_result);
     assert_status_terminated(status, sizeof(status));
 
     init_params(&cur, &prev, &enh);
     data_result = hard_result;
-    ret = mbe_processAmbe2400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe2400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     assert_float_pcm_sane(out_f);
 
     init_params(&cur, &prev, &enh);
     data_result = hard_result;
-    ret = mbe_processAmbe2400Data(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe2400Data(out_s, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processAmbe3600x2400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe3600x2400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_float_pcm_sane(out_f);
@@ -121,19 +121,19 @@ test_ambe2400_frame_paths(void) {
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processAmbe3600x2400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe3600x2400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_status_terminated(status, sizeof(status));
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processAmbe3600x2400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe3600x2400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
     assert_float_pcm_sane(out_f);
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processAmbe3600x2400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processAmbe3600x2400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
 }
@@ -173,7 +173,7 @@ test_imbe7200_frame_paths(void) {
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
     data_result = hard_result;
-    ret = mbe_processImbe4400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe4400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &data_result);
     assert_float_pcm_sane(out_f);
@@ -182,25 +182,25 @@ test_imbe7200_frame_paths(void) {
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
     data_result = hard_result;
-    ret = mbe_processImbe4400Data(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe4400Data(out_s, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &data_result);
     assert_status_terminated(status, sizeof(status));
 
     init_params(&cur, &prev, &enh);
     data_result = hard_result;
-    ret = mbe_processImbe4400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe4400Dataf(out_f, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
     assert_float_pcm_sane(out_f);
 
     init_params(&cur, &prev, &enh);
     data_result = hard_result;
-    ret = mbe_processImbe4400Data(out_s, &data_result, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe4400Data(out_s, &data_result, hard_d, &cur, &prev, &enh);
     assert_result_total(&data_result, ret);
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processImbe7200x4400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7200x4400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_float_pcm_sane(out_f);
@@ -208,19 +208,19 @@ test_imbe7200_frame_paths(void) {
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processImbe7200x4400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7200x4400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_status_terminated(status, sizeof(status));
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processImbe7200x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7200x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
     assert_float_pcm_sane(out_f);
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processImbe7200x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7200x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
 }
@@ -258,7 +258,7 @@ test_imbe7100_frame_paths(void) {
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processImbe7100x4400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7100x4400Framef(out_f, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_float_pcm_sane(out_f);
@@ -266,19 +266,19 @@ test_imbe7100_frame_paths(void) {
 
     init_params(&cur, &prev, &enh);
     memset(status, 0, sizeof(status));
-    ret = mbe_processImbe7100x4400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7100x4400Frame(out_s, &hard_result, const_frame, hard_d, &cur, &prev, &enh);
     assert_result_total(&hard_result, ret);
     mbe_formatProcessResult(status, sizeof(status), &hard_result);
     assert_status_terminated(status, sizeof(status));
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processImbe7100x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7100x4400SoftFramef(out_f, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
     assert_float_pcm_sane(out_f);
 
     init_params(&cur, &prev, &enh);
-    ret = mbe_processImbe7100x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh, 8);
+    ret = mbe_processImbe7100x4400SoftFrame(out_s, &soft_result, const_soft_frame, soft_d, &cur, &prev, &enh);
     assert_result_total(&soft_result, ret);
     assert((soft_result.flags & MBE_PROCESS_FLAG_SOFT_INPUT) != 0u);
 }

--- a/tests/test_golden_pcm.c
+++ b/tests/test_golden_pcm.c
@@ -91,7 +91,7 @@ main(void) {
     mbe_setThreadRngSeed(0xC0FFEEu);
     fill_params(&cur, &prev);
     /* First run */
-    mbe_synthesizeSpeechf(out_f, &cur, &prev, 8);
+    mbe_synthesizeSpeechf(out_f, &cur, &prev);
     uint32_t hf1 = fnv1a32(out_f, sizeof(out_f));
     mbe_floattoshort(out_f, out_s);
     uint32_t hs1 = fnv1a32(out_s, sizeof(out_s));
@@ -103,7 +103,7 @@ main(void) {
     short out_s2[160];
     mbe_setThreadRngSeed(0xC0FFEEu);
     fill_params(&cur, &prev);
-    mbe_synthesizeSpeechf(out_f2, &cur, &prev, 8);
+    mbe_synthesizeSpeechf(out_f2, &cur, &prev);
     for (int i = 0; i < 160; ++i) {
         if (!float_bits_equal(out_f[i], out_f2[i])) {
             fprintf(stderr, "determinism failure: float sample %d differs across runs\n", i);

--- a/tests/test_input_validation.c
+++ b/tests/test_input_validation.c
@@ -10,6 +10,7 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "mbelib-neo/mbelib.h"
@@ -115,7 +116,7 @@ test_invalid_parameter_bits_rejected_before_synthesis(void) {
     mbe_initProcessResult(&result);
     params[8] = 3;
 
-    assert(mbe_processAmbe2400Dataf(out, &result, params, &cur, &prev, &enh, 8) == MBE_STATUS_INVALID_BITS);
+    assert(mbe_processAmbe2400Dataf(out, &result, params, &cur, &prev, &enh) == MBE_STATUS_INVALID_BITS);
     assert_float_buffer_unchanged(out, 123.0f);
 }
 
@@ -128,7 +129,7 @@ process_imbe4400_with_result_context(const mbe_process_result* context) {
 
     init_params(&cur, &prev, &enh);
 
-    return mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8);
+    return mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh);
 }
 
 static void
@@ -187,6 +188,17 @@ test_invalid_result_context_rejected(void) {
     expect_invalid_result_context(result);
 
     mbe_initProcessResult(&result);
+    result.flags = 0x80000000u;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
+    result.flags = MBE_PROCESS_FLAG_C0_VALID;
+    result.c0_errors = 2;
+    result.protected_errors = 1;
+    result.total_errors = 4;
+    expect_invalid_result_context(result);
+
+    mbe_initProcessResult(&result);
     result.c0_errors = 100;
     result.protected_errors = 84;
     expect_valid_result_context(result);
@@ -211,7 +223,7 @@ test_invalid_harmonic_counts_rejected_by_raw_helpers(void) {
             out[j] = 123.0f;
         }
         cur.L = invalid_l;
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert_float_buffer_unchanged(out, 0.0f);
 
         init_params(&cur, &prev, &enh);
@@ -219,7 +231,7 @@ test_invalid_harmonic_counts_rejected_by_raw_helpers(void) {
             out[j] = 123.0f;
         }
         prev.L = invalid_l;
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert_float_buffer_unchanged(out, 0.0f);
 
         init_params(&cur, &prev, &enh);
@@ -227,7 +239,7 @@ test_invalid_harmonic_counts_rejected_by_raw_helpers(void) {
             out_s[j] = 123;
         }
         cur.L = invalid_l;
-        mbe_synthesizeSpeech(out_s, &cur, &prev, 8);
+        mbe_synthesizeSpeech(out_s, &cur, &prev);
         assert_short_buffer_unchanged(out_s, 0);
 
         init_params(&cur, &prev, &enh);
@@ -285,7 +297,7 @@ test_imbe_previous_harmonic_count_is_clamped_for_processing(void) {
         prev.log2Ml[56] = 0.5f;
         fill_float_buffer(out, 123.0f);
 
-        assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh) >= 0);
         assert(cur.L == 56);
     }
 }
@@ -305,7 +317,7 @@ test_imbe_previous_harmonic_count_upper_endpoint_is_safe(void) {
     prev.log2Ml[56] = 1.0f;
     fill_float_buffer(out, 123.0f);
 
-    assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh, 8) >= 0);
+    assert(mbe_processImbe4400Dataf(out, &result, params, &cur, &prev, &enh) >= 0);
     assert(cur.L == 56);
 }
 
@@ -320,15 +332,14 @@ stamp_params(mbe_parms* mp, int marker) {
     mp->PHIl[1] = (float)marker + 1.0f;
     mp->PSIl[1] = (float)marker + 1.25f;
     mp->gamma = (float)marker + 1.5f;
-    mp->un = marker + 3;
-    mp->repeat = marker + 4;
-    mp->swn = marker + 5;
+    mp->tonePhase = (uint32_t)(marker + 3);
+    mp->swn = marker + 4;
     mp->localEnergy = (float)marker + 1.75f;
-    mp->amplitudeThreshold = marker + 6;
+    mp->amplitudeThreshold = marker + 5;
     mp->errorRate = (float)marker + 2.0f;
-    mp->errorCountTotal = marker + 7;
-    mp->errorCount4 = marker + 8;
-    mp->repeatCount = marker + 9;
+    mp->errorCountTotal = marker + 6;
+    mp->errorCount4 = marker + 7;
+    mp->repeatCount = marker + 8;
     mp->mutingThreshold = (float)marker + 2.25f;
     mp->previousUw[0] = (float)marker + 2.5f;
     mp->noiseSeed = (float)marker + 2.75f;
@@ -346,15 +357,14 @@ assert_params_stamp(const mbe_parms* mp, int marker) {
     assert(mp->PHIl[1] == (float)marker + 1.0f);
     assert(mp->PSIl[1] == (float)marker + 1.25f);
     assert(mp->gamma == (float)marker + 1.5f);
-    assert(mp->un == marker + 3);
-    assert(mp->repeat == marker + 4);
-    assert(mp->swn == marker + 5);
+    assert(mp->tonePhase == (uint32_t)(marker + 3));
+    assert(mp->swn == marker + 4);
     assert(mp->localEnergy == (float)marker + 1.75f);
-    assert(mp->amplitudeThreshold == marker + 6);
+    assert(mp->amplitudeThreshold == marker + 5);
     assert(mp->errorRate == (float)marker + 2.0f);
-    assert(mp->errorCountTotal == marker + 7);
-    assert(mp->errorCount4 == marker + 8);
-    assert(mp->repeatCount == marker + 9);
+    assert(mp->errorCountTotal == marker + 6);
+    assert(mp->errorCount4 == marker + 7);
+    assert(mp->repeatCount == marker + 8);
     assert(mp->mutingThreshold == (float)marker + 2.25f);
     assert(mp->previousUw[0] == (float)marker + 2.5f);
     assert(mp->noiseSeed == (float)marker + 2.75f);

--- a/tests/test_noise_determinism.c
+++ b/tests/test_noise_determinism.c
@@ -61,10 +61,10 @@ main(void) {
 
     /* Test 1: Determinism - same initial state produces identical output */
     fill_params_unvoiced(&cur1, &prev1);
-    mbe_synthesizeSpeechf(out1, &cur1, &prev1, 8);
+    mbe_synthesizeSpeechf(out1, &cur1, &prev1);
 
     fill_params_unvoiced(&cur2, &prev2);
-    mbe_synthesizeSpeechf(out2, &cur2, &prev2, 8);
+    mbe_synthesizeSpeechf(out2, &cur2, &prev2);
 
     for (int i = 0; i < 160; ++i) {
         if (!float_bits_equal(out1[i], out2[i])) {
@@ -76,7 +76,7 @@ main(void) {
     /* Test 2: State progression - consecutive frames produce different noise
      * (LCG state advances, so second frame should differ from first) */
     mbe_moveMbeParms(&cur1, &prev1); // advance: cur becomes prev for next frame
-    mbe_synthesizeSpeechf(out3, &cur1, &prev1, 8);
+    mbe_synthesizeSpeechf(out3, &cur1, &prev1);
 
     int diff = 0;
     for (int i = 0; i < 160; ++i) {
@@ -94,7 +94,7 @@ main(void) {
     mbe_parms cur_check, prev_check;
     fill_params_unvoiced(&cur_check, &prev_check);
     float seed_before = cur_check.noiseSeed;
-    mbe_synthesizeSpeechf(out1, &cur_check, &prev_check, 8);
+    mbe_synthesizeSpeechf(out1, &cur_check, &prev_check);
     float seed_after = cur_check.noiseSeed;
 
     if (float_bits_equal(seed_before, seed_after)) {

--- a/tests/test_params.c
+++ b/tests/test_params.c
@@ -355,12 +355,13 @@ main(void) {
         mbe_initMbeParms(&cur_a, &prev_a, &prev_enh_a);
         init_result_total(&result_a, 5);
         result_a.c0_errors = 0;
-        assert(mbe_processAmbe2450Dataf(out, &result_a, ambe_d, &cur_a, &prev_a, &prev_enh_a, 8) >= 0);
+        assert(mbe_processAmbe2450Dataf(out, &result_a, ambe_d, &cur_a, &prev_a, &prev_enh_a) >= 0);
 
         mbe_initMbeParms(&cur_b, &prev_b, &prev_enh_b);
         init_result_total(&result_b, 5);
         result_b.c0_errors = 4;
-        assert(mbe_processAmbe2450Dataf(out, &result_b, ambe_d, &cur_b, &prev_b, &prev_enh_b, 8) >= 0);
+        result_b.protected_errors = 1;
+        assert(mbe_processAmbe2450Dataf(out, &result_b, ambe_d, &cur_b, &prev_b, &prev_enh_b) >= 0);
 
         assert(cur_a.repeatCount == cur_b.repeatCount);
         assert(result_has_marker(&result_a, 'R') == result_has_marker(&result_b, 'R'));
@@ -381,12 +382,13 @@ main(void) {
         mbe_initMbeParms(&cur_a, &prev_a, &prev_enh_a);
         init_result_total(&result_a, 11);
         result_a.c0_errors = 0;
-        assert(mbe_processImbe4400Dataf(out, &result_a, imbe_d, &cur_a, &prev_a, &prev_enh_a, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result_a, imbe_d, &cur_a, &prev_a, &prev_enh_a) >= 0);
 
         mbe_initMbeParms(&cur_b, &prev_b, &prev_enh_b);
         init_result_total(&result_b, 11);
         result_b.c0_errors = 2;
-        assert(mbe_processImbe4400Dataf(out, &result_b, imbe_d, &cur_b, &prev_b, &prev_enh_b, 8) >= 0);
+        result_b.protected_errors = 9;
+        assert(mbe_processImbe4400Dataf(out, &result_b, imbe_d, &cur_b, &prev_b, &prev_enh_b) >= 0);
 
         assert(cur_a.repeatCount == cur_b.repeatCount);
         assert(result_has_marker(&result_a, 'R') == result_has_marker(&result_b, 'R'));
@@ -443,12 +445,12 @@ main(void) {
 
         mbe_initMbeParms(&cur, &prev, &prev_enh);
         init_result_total(&result, 5);
-        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh) >= 0);
         assert(result_has_marker(&result, 'T'));
 
         mbe_initMbeParms(&cur, &prev, &prev_enh);
         init_result_total(&result, 6);
-        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d, &cur, &prev, &prev_enh) >= 0);
         assert(!result_has_marker(&result, 'T'));
         assert(result_has_marker(&result, 'E'));
         assert(approx_equal(cur.w0, 0.0f, 1e-6f));
@@ -483,11 +485,10 @@ main(void) {
         cur_a.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
         prev_a.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
         prev_enh_a.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
-        prev_a.repeat = MBE_MAX_FRAME_REPEATS;
         prev_a.repeatCount = MBE_MAX_FRAME_REPEATS;
 
         init_result_total(&result, 0);
-        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d_a, &cur_a, &prev_a, &prev_enh_a, 8) >= 0);
+        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d_a, &cur_a, &prev_a, &prev_enh_a) >= 0);
         assert(result_has_marker(&result, 'T'));
         assert(approx_equal(cur_a.w0, custom_w0, 1e-6f));
         assert(cur_a.L == custom_L);
@@ -501,11 +502,10 @@ main(void) {
         cur_b.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
         prev_b.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
         prev_enh_b.mutingThreshold = MBE_MUTING_THRESHOLD_AMBE;
-        prev_b.repeat = MBE_MAX_FRAME_REPEATS;
         prev_b.repeatCount = MBE_MAX_FRAME_REPEATS;
 
         init_result_total(&result, 0);
-        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d_b, &cur_b, &prev_b, &prev_enh_b, 8) >= 0);
+        assert(mbe_processAmbe2450Dataf(out, &result, ambe_d_b, &cur_b, &prev_b, &prev_enh_b) >= 0);
         assert(result_has_marker(&result, 'T'));
         assert(approx_equal(cur_b.w0, custom_w0, 1e-6f));
         assert(cur_b.L == custom_L);
@@ -521,7 +521,7 @@ main(void) {
         cur.errorRate = 1.0f;
         cur.repeatCount = 0;
         float ambe_seed_before = cur.noiseSeed;
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert(float_bits_differ(cur.noiseSeed, ambe_seed_before));
 
         seed_speech_params(&cur, &prev);
@@ -529,7 +529,7 @@ main(void) {
         cur.errorRate = 1.0f;
         cur.repeatCount = 0;
         float imbe_seed_before = cur.noiseSeed;
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert(float_bits_equal(cur.noiseSeed, imbe_seed_before));
     }
 
@@ -544,7 +544,7 @@ main(void) {
         cur.repeatCount = 0;
 
         float local_before = cur.localEnergy;
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert(float_bits_differ(cur.localEnergy, local_before));
     }
 
@@ -558,7 +558,7 @@ main(void) {
         const float raw_prev_phase = (20.0f * (float)M_PI) + 0.321f;
         prev.PSIl[l_test] = raw_prev_phase;
 
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
 
         float wrapped_prev = fmodf(raw_prev_phase, (float)(2.0 * M_PI));
         if (wrapped_prev < 0.0f) {
@@ -613,7 +613,7 @@ main(void) {
         cur.noiseSeed = -1.0f;
         memset(cur.noiseOverlap, 0, sizeof(cur.noiseOverlap));
         mbe_setThreadRngSeed(0x1234u);
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
         assert(approx_equal(cur.noiseSeed, (float)(0x1234u % 53125u), 1e-6f));
     }
 
@@ -633,7 +633,7 @@ main(void) {
         }
         prev = cur;
 
-        mbe_synthesizeSpeechf(out, &cur, &prev, 8);
+        mbe_synthesizeSpeechf(out, &cur, &prev);
 
         int l_test = cur.L;
         float expected_psil = prev.PSIl[l_test] + ((prev.w0 + cur.w0) * ((float)(l_test * 160) / 2.0f));
@@ -656,7 +656,7 @@ main(void) {
         cur.errorCount4 = 7;
         prev.errorCount4 = 3;
 
-        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh) >= 0);
         assert(cur.errorCount4 == 0);
     }
 
@@ -678,7 +678,7 @@ main(void) {
         result.protected_errors = 3;
         result.total_errors = 3;
 
-        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh) >= 0);
         assert(cur.errorCount4 == 3);
     }
 
@@ -698,7 +698,7 @@ main(void) {
         result.c0_errors = 1;
         result.total_errors = 1;
 
-        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh) >= 0);
         assert(cur.errorCount4 == 0);
     }
 
@@ -726,13 +726,11 @@ main(void) {
         set_imbe7200_b0(imbe_d, 0);
         init_result_total(&result, 6);
 
-        prev.repeat = 4;
         prev.repeatCount = 4;
         cur = prev;
 
-        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh) >= 0);
 
-        assert(cur.repeat == 0);
         assert(cur.repeatCount == 0);
         assert(cur.L == 39);
         float w0_default = (float)((4.0 * M_PI) / (134.0 + 39.5));
@@ -761,7 +759,7 @@ main(void) {
         cur.repeatCount = 0;
 
         float noise_seed_before = prev_enh.noiseSeed;
-        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh, 8) >= 0);
+        assert(mbe_processImbe4400Dataf(out, &result, imbe_d, &cur, &prev, &prev_enh) >= 0);
         assert(float_bits_equal(prev_enh.noiseSeed, noise_seed_before));
     }
 

--- a/tools/gen_golden.c
+++ b/tools/gen_golden.c
@@ -61,7 +61,7 @@ main(void) {
 
     mbe_setThreadRngSeed(0xC0FFEEu);
     fill_params(&cur, &prev);
-    mbe_synthesizeSpeechf(out_f, &cur, &prev, 8);
+    mbe_synthesizeSpeechf(out_f, &cur, &prev);
 
     // Hash float bytes and also short bytes after conversion
     uint32_t hf = fnv1a32(out_f, sizeof(out_f));

--- a/tools/lizard.sh
+++ b/tools/lizard.sh
@@ -14,8 +14,8 @@ Usage: tools/lizard.sh [--strict] [--ccn N] [--length N] [--arguments N] [--] [p
 Options:
   --strict       Fail when threshold warnings are emitted.
   --ccn N        Cyclomatic complexity warning threshold (default: 15).
-  --length N     Function length warning threshold (default: 1000; strict: 120).
-  --arguments N  Parameter count warning threshold (default: 100; strict: 13).
+  --length N     Function length warning threshold (default: 1000; strict: 100).
+  --arguments N  Parameter count warning threshold (default: 100; strict: 10).
 
 Arguments:
   paths...       Optional paths to scan. Default: src include fuzz
@@ -89,8 +89,8 @@ if [[ $STRICT -eq 1 ]]; then
   # Keep the current maximum CCN as the strict ceiling, but make length and
   # parameter-count budgets useful enough to catch future growth.
   [[ $CCN_SET -eq 0 ]] && CCN=15
-  [[ $LENGTH_SET -eq 0 ]] && LENGTH=120
-  [[ $ARGUMENTS_SET -eq 0 ]] && ARGUMENTS=13
+  [[ $LENGTH_SET -eq 0 ]] && LENGTH=100
+  [[ $ARGUMENTS_SET -eq 0 ]] && ARGUMENTS=10
 fi
 
 if ! command -v lizard > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Tighten local strictness with additional compiler warnings, semgrep rules, and lower lizard thresholds.
- Remove unreleased v2 compatibility shims: `MBELIB_STRICT_ORDER`, ignored `uvquality` parameters, legacy `repeat`, and legacy `un`.
- Replace unchecked binary string parsing with bit accumulation helpers and add checked benchmark argument parsing.
- Harden `mbe_process_result` validation for unknown flags and inconsistent error totals.
- Update tests, fuzzers, benchmarks, docs, and generators for the cleaned API.

## Validation

- `tools/format.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/lizard.sh --strict`
- `semgrep --config semgrep/mbelib-neo.yml --error --quiet`
- `tools/preflight_ci.sh`
- benchmark-enabled warning build in `build/strict-bench`
- `cmake --preset asan-ubsan-debug && cmake --build --preset asan-ubsan-debug -j && ctest --preset asan-ubsan-debug --output-on-failure`

Note: the sanitizer link emitted system `libasan` warnings about temp APIs, but all sanitizer tests passed.