### PR TITLE
ci: normalize release SBOM asset names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -858,6 +858,40 @@ jobs:
               exit 1
             fi
           done
+          for package in "${packages[@]}"; do
+            package_name="$(basename "$package")"
+            package_stem="${package_name%.tar.gz}"
+            package_stem="${package_stem%.zip}"
+            platform_arch="${package_stem#"${ARCHIVE_PREFIX}-"}"
+            platform="${platform_arch%-*}"
+            arch="${platform_arch##*-}"
+
+            case "${platform}" in
+              linux) artifact_os="Linux" ;;
+              macos) artifact_os="macOS" ;;
+              windows) artifact_os="Windows" ;;
+              *)
+                echo "Unsupported release package platform: ${platform}" >&2
+                exit 1
+                ;;
+            esac
+            case "${arch}" in
+              x64) artifact_arch="X64" ;;
+              arm64) artifact_arch="ARM64" ;;
+              *)
+                echo "Unsupported release package architecture: ${arch}" >&2
+                exit 1
+                ;;
+            esac
+
+            artifact_sbom="dist/release-package-${artifact_os}-${artifact_arch}.spdx.json"
+            if [ ! -f "${artifact_sbom}" ]; then
+              echo "Missing SBOM artifact for ${package_name}: ${artifact_sbom}" >&2
+              find dist -maxdepth 1 -type f -print >&2
+              exit 1
+            fi
+            mv "${artifact_sbom}" "${package}.spdx.json"
+          done
           mapfile -t sboms < <(
             find dist -maxdepth 1 -type f -name "${ARCHIVE_PREFIX}-*.spdx.json" |
               sort


### PR DESCRIPTION
## Summary

- Normalize downloaded release-package SBOM artifact names to match the archive-specific release asset names before publish verification.
- Preserve the existing checksum, attestation, and release asset validation after the rename.
- Fixes the `v2.0.0` publish failure where SBOM artifacts were downloaded as `release-package-<OS>-<ARCH>.spdx.json` but the publish job expected `mbelib-neo-<version>-<platform>-<arch>.<ext>.spdx.json`.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer when practical, or document solo-maintainer residual risk below.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to mbelib-neo conventions.
- [x] Non-trivial commits include DCO `Signed-off-by` lines.

## Quality Review

- [x] New decoder, file input, allocator, threading, dependency, or public API changes include focused tests.
- [x] Codec, DSP, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new direct bundled-third-party includes, shell execution, broad workflow permissions, or release publishing paths were added without justification.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [x] `tools/zizmor.sh` for workflow changes
- [x] `tools/check_workflow_git_pins.sh` and `tools/check_workflow_download_pins.sh` for workflow source/download pin changes
- [ ] `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release` for release hardening changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/workflow_lint.sh`
- [x] local shell simulation of release SBOM rename logic

## Risk

- Security/dependency impact: workflow-only change; no new permissions, actions, downloads, or dependencies.
- API/ABI compatibility impact: none.
- Packaging/release impact: fixes release asset publishing for package SBOM names; final validation will be the rerun tag release workflow after merge.