### PR TITLE
ci: avoid duplicate release package attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -915,10 +915,6 @@ jobs:
             ) >> dist/SHA256SUMS.txt
           done
           cat dist/SHA256SUMS.txt
-      - name: Attest release packages
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-checksums: dist/SHA256SUMS.txt
       - name: Attest checksum manifest
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:

--- a/tools/semgrep.sh
+++ b/tools/semgrep.sh
@@ -106,10 +106,40 @@ if [[ -n "${MBE_SEMGREP_SARIF_OUT:-}" ]]; then
   ARGS+=(--sarif --output "$MBE_SEMGREP_SARIF_OUT")
 fi
 
-set +e
-semgrep "${ARGS[@]}" "${TARGETS[@]}" 2>&1 | tee "$LOG_FILE"
-rc=${PIPESTATUS[0]}
-set -e
+run_semgrep() {
+  local append_log=0
+  local rc=0
+  local -a tee_args=("$LOG_FILE")
+
+  if [[ "${1:-}" == "--append-log" ]]; then
+    append_log=1
+    shift
+  fi
+  if [[ $append_log -eq 1 ]]; then
+    tee_args=(-a "$LOG_FILE")
+  fi
+
+  set +e
+  semgrep "$@" 2>&1 | tee "${tee_args[@]}"
+  rc=${PIPESTATUS[0]}
+  set -e
+  return "$rc"
+}
+
+if run_semgrep "${ARGS[@]}" "${TARGETS[@]}"; then
+  rc=0
+else
+  rc=$?
+fi
+
+if [[ $rc -ne 0 ]] && grep -q 'io_uring_queue_init' "$LOG_FILE"; then
+  echo "Semgrep failed while initializing io_uring; retrying with legacy parallelism." | tee -a "$LOG_FILE" >&2
+  if run_semgrep --append-log --x-parmap "${ARGS[@]}" "${TARGETS[@]}"; then
+    rc=0
+  else
+    rc=$?
+  fi
+fi
 
 if [[ $rc -eq 0 ]]; then
   echo "Semgrep completed. Full output in $LOG_FILE"


### PR DESCRIPTION
## Summary

- Remove the publish job's duplicate package-level attestation, leaving package provenance and SBOM attestations in `package-release`.
- Keep the publish job's checksum manifest attestation for `SHA256SUMS.txt`.
- Retry Semgrep only for the observed `io_uring_queue_init` startup failure using legacy parallelism, so local hooks can still fail normally on findings or unrelated engine errors.

## Release attestation cleanup

Removed stale or unnecessary `v2.0.0` attestations by ID:

- `29558961`: duplicate publish-job multi-subject package provenance for the final release archives
- `29556405`, `29556401`: stale failed-run Linux package attestations
- `29556413`, `29556409`: stale failed-run macOS package attestations
- `29556530`, `29556522`: stale failed-run Windows package attestations

Kept the needed final release attestations:

- package provenance and SBOM attestations for each release archive
- checksum manifest attestation for `SHA256SUMS.txt`

Verified current counts after cleanup: each final release archive has 2 attestations, `SHA256SUMS.txt` has 1, and the stale failed-run archive digests have 0.

## Validation

- `tools/shell_lint.sh tools/semgrep.sh`
- `tools/semgrep.sh --strict -- .github/workflows/ci.yml tools/semgrep.sh`
- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- `tools/check_workflow_git_pins.sh && tools/check_workflow_download_pins.sh`
- `git push` pre-push hook: workflow pin guardrails, Semgrep strict, shell lint, Lizard complexity

C build and CTest gates were not run because this changes only workflow and shell tooling.