### PR TITLE
ci: synchronize CodeQL action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       timezone: "America/Chicago"
     cooldown:
       default-days: 7
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Upload Semgrep SARIF
         if: always() && hashFiles('.semgrep.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .semgrep.sarif
       - name: Upload Semgrep output

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,14 +38,14 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.build-mode == ''
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Initialize CodeQL with build mode
         if: matrix.build-mode != ''
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -60,4 +60,4 @@ jobs:
         run: cmake --build --preset dev-debug --target mbe-codeql-first-party -j
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('.gitleaks.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .gitleaks.sarif
 
@@ -192,7 +192,7 @@ jobs:
       - name: Upload zizmor SARIF
         if: always() && hashFiles('.zizmor.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .zizmor.sarif
 
@@ -241,7 +241,7 @@ jobs:
       - name: Upload OSV SARIF
         if: always() && hashFiles('.osv-scanner.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .osv-scanner.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload Scorecard SARIF
         if: always() && hashFiles('scorecard.sarif') != ''
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: scorecard.sarif
 


### PR DESCRIPTION
## Summary

- Update every `github/codeql-action` use from v4.36.2 to the immutable v4.37.0 commit.
- Group future `github/codeql-action/*` Dependabot updates into one pull request.
- Supersede #47, #48, and #49 with a synchronized update.

Dependabot treated `init`, `analyze`, and `upload-sarif` as independent dependencies. Updating `init` or `analyze` alone caused CodeQL to reject the mixed action state with a configuration-version mismatch. Keeping all components on the same commit fixes the failing CodeQL jobs and prevents the same split-update failure from recurring.

There is no runtime library, public API, ABI, codec, packaging, or release behavior change.

## Review

- [ ] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer when practical, or document solo-maintainer residual risk below.
- [ ] Copied, generated, or bulk-written code has been read, understood, and adapted to mbelib-neo conventions.
- [x] Non-trivial commits include DCO `Signed-off-by` lines.

## Quality Review

- [ ] New decoder, file input, allocator, threading, dependency, or public API changes include focused tests.
- [x] Codec, DSP, workflow, dependency, and release changes received extra scrutiny.
- [ ] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new direct bundled-third-party includes, shell execution, broad workflow permissions, or release publishing paths were added without justification.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [x] `tools/zizmor.sh` for workflow changes
- [x] `tools/check_workflow_git_pins.sh` and `tools/check_workflow_download_pins.sh` for workflow source/download pin changes
- [ ] `tools/check_release_hardening.sh build/dev-release/libmbe-neo.so build/dev-release` for release hardening changes
- [x] `tools/osv_scan.sh` for dependency input changes

## Risk

- Security/dependency impact: Low. All action references remain pinned to a verified immutable commit; the update moves the full CodeQL action set to v4.37.0.
- API/ABI compatibility impact: None.
- Packaging/release impact: None.

Residual risk is limited to behavior that can only be exercised by the hosted GitHub Actions environment. The local workflow, security, dependency, secret, and static-analysis checks all passed.
