### PR TITLE
ci: skip AUR update when aur.archlinux.org is in maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,8 +361,32 @@ jobs:
           chmod 600 "$HOME/.ssh/aur"
           ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
-      - name: Clone AUR package
+      # aur.archlinux.org gates its SSH git endpoint behind a maintenance flag
+      # (e.g. the 2026 AUR supply-chain incident), which makes every clone fail
+      # with exit 128 and turns main red even though the build is fine. Probe
+      # git-serve first and skip the update when it reports maintenance; any
+      # other probe failure (auth, DNS, host key) still fails the job loudly.
+      - name: Check AUR availability
+        id: aur_up
         if: steps.aur_key.outputs.has_key == 'true'
+        run: |
+          ssh_opts=(-i "$HOME/.ssh/aur" -o IdentitiesOnly=yes -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=30)
+          probe_out="$(ssh "${ssh_opts[@]}" aur@aur.archlinux.org help 2>&1)" && probe_rc=0 || probe_rc=$?
+          printf '%s\n' "$probe_out"
+          if [ "$probe_rc" -eq 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s' "$probe_out" | grep -qi 'down due to maintenance'; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=AUR update skipped::aur.archlinux.org is in maintenance mode; the AUR package was not updated for this run."
+            exit 0
+          fi
+          echo "AUR SSH probe failed with exit $probe_rc for a reason other than maintenance." >&2
+          exit "$probe_rc"
+
+      - name: Clone AUR package
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/mbelib-neo-git.git aur-package
@@ -370,7 +394,7 @@ jobs:
 
       - name: Compute new pkgver
         id: pkgver
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd "$GITHUB_WORKSPACE"
           ref="origin/main"
@@ -385,7 +409,7 @@ jobs:
           echo "Computed pkgver from $ref ($(git rev-parse --short=7 "$ref")): $new_pkgver"
 
       - name: Validate AUR VCS metadata
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -412,7 +436,7 @@ jobs:
 
       - name: Check if update needed
         id: check
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd aur-package
           current_pkgver=$(grep -E '^\s*pkgver=' PKGBUILD | sed 's/.*pkgver=//')
@@ -427,7 +451,7 @@ jobs:
           fi
 
       - name: Update PKGBUILD
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -437,7 +461,7 @@ jobs:
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --printsrcinfo > .SRCINFO"
 
       - name: Commit and push to AUR
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           cd aur-package
           git config user.name "github-actions[bot]"
@@ -501,8 +525,30 @@ jobs:
           chmod 600 "$HOME/.ssh/aur"
           ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
-      - name: Clone AUR package
+      # Same maintenance gate as update-aur-git. This skip is louder (warning,
+      # not notice) because a tagged release that never reaches the AUR needs
+      # to be pushed by hand once maintenance lifts.
+      - name: Check AUR availability
+        id: aur_up
         if: steps.aur_key.outputs.has_key == 'true'
+        run: |
+          ssh_opts=(-i "$HOME/.ssh/aur" -o IdentitiesOnly=yes -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=30)
+          probe_out="$(ssh "${ssh_opts[@]}" aur@aur.archlinux.org help 2>&1)" && probe_rc=0 || probe_rc=$?
+          printf '%s\n' "$probe_out"
+          if [ "$probe_rc" -eq 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s' "$probe_out" | grep -qi 'down due to maintenance'; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=AUR release update skipped::aur.archlinux.org is in maintenance mode; ${GITHUB_REF_NAME} was NOT published to the AUR. Re-run this job or update the package manually once maintenance lifts."
+            exit 0
+          fi
+          echo "AUR SSH probe failed with exit $probe_rc for a reason other than maintenance." >&2
+          exit "$probe_rc"
+
+      - name: Clone AUR package
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/mbelib-neo.git aur-package
@@ -510,7 +556,7 @@ jobs:
 
       - name: Compute release metadata
         id: release_meta
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           pkgver="${GITHUB_REF_NAME#v}"
           source_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
@@ -524,7 +570,7 @@ jobs:
 
       - name: Check if update needed
         id: check
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd aur-package
           current_pkgver=$(sed -n 's/^pkgver=//p' PKGBUILD | head -n1)
@@ -543,7 +589,7 @@ jobs:
           fi
 
       - name: Update PKGBUILD
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -554,14 +600,14 @@ jobs:
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --printsrcinfo > .SRCINFO"
 
       - name: Validate AUR release source
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --verifysource --nodeps --noconfirm"
 
       - name: Commit and push to AUR
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           cd aur-package
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
While `aur.archlinux.org` has its maintenance flag set, `git-serve` answers every SSH request with "The AUR is down due to maintenance" and the clone exits 128. Both AUR jobs fail as a result, so every push to `main` ends red even though all build and test jobs pass. Read-only HTTPS stays up during maintenance, so the outage is only visible on the `ssh://` path the jobs use.

## Change

Probe `git-serve` with `ssh aur@aur.archlinux.org help` before cloning, and record the result in a step output that gates the clone and everything after it, in both `update-aur-git` and `update-aur-release`:

| probe result | behavior |
| --- | --- |
| exits 0 | update proceeds unchanged |
| `down due to maintenance` | job skips the update and stays green |
| any other failure | job fails with the ssh exit code |

Auth failures, DNS problems, and host key mismatches keep failing loudly; only the maintenance flag is tolerated. The probe runs under the existing `AUR_SSH_PRIVATE_KEY` check, so a missing key leaves the new output unset and the downstream steps skip exactly as before.

The release job emits a warning rather than a notice and names the tag, because a tagged release that never reaches the AUR has to be pushed by hand once maintenance lifts.

Mirrors the same procedure already in place in dsd-neo.

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- `zizmor --persona=auditor .github/workflows/ci.yml` — no new findings in the added steps' line ranges
